### PR TITLE
Fixed error for `docker-compose build`.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   # web conference demo
   web:
     build:
-      dockerfile: web.Dockerfile
+      dockerfile: ./docker/web.Dockerfile
       context: .
     volumes:
       - "./configs:/cert"
@@ -30,7 +30,7 @@ services:
   biz:
     build:
       dockerfile: ./docker/biz.Dockerfile
-      context: docker
+      context: .
     command: "-c /configs/biz.toml"
     volumes:
       - "./docker/biz.toml:/configs/biz.toml"


### PR DESCRIPTION
#### Description
```bash
$ docker-compose build
nats uses an image, skipping
etcd uses an image, skipping
redis uses an image, skipping
Building biz
ERROR: Cannot locate specified Dockerfile: ./docker/biz.Dockerfile
ERROR: Cannot locate specified Dockerfile: web.Dockerfile
```
#### Reference issue
Fixes #...
