### PR TITLE
[WIP] Autocreate certificates using Caddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Welcome contributing to ion!
 ./scripts/installDeps.sh
 
 #docker
-Building is not required, pre-made images are hosted
+Step is not required for Docker
 ```
 
 ### 3. run

--- a/README.md
+++ b/README.md
@@ -65,35 +65,35 @@ Welcome contributing to ion!
 <img width="360" height="265" src="screenshots/web/ion-04.jpg"/> <img width="360" height="265" src="screenshots/web/ion-05.jpg"/>
 
 ## How to use
+### Docker
+The provided docker-compose works for deploying to open usage, and can also be used for local development. It also supports auto-generate of certificates via LetsEncrypt.
 
-### 1. make key
+It accepts the following enviroment variables.
+* `WWW_URL` -- Public URL if auto-generating certificates
+* `ADMIN_EMAIL`  -- Email if auto-generating certificates
 
+To run on `conference.pion.ly` you would run `WWW_URL=conference.pion.ly ADMIN_EMAIL=admin@pion.ly docker-compose up`
+
+If `WWW_URL` is set you will access via `https://yourip:8080` OR `http://yourip:8080` if not running with TLS enabled.
+
+
+### Scripts
+#### 1. make key
 ```
 ./scripts/makeKey.sh
 ```
 
-### 2. build
-
+#### 2. build
 ```
-#non-docker
 ./scripts/installDeps.sh
-
-#docker
-Step is not required for Docker
 ```
 
-### 3. run
-
+#### 3. run
 ```
-#non-docker
-./scripts/allRestart.sh
-
-#docker
 docker-compose up
 ```
 
-### 4. let's chat
-
+#### 4. let's chat
 Open this url with chrome
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,16 @@ services:
     #   context: .
     image: pionwebrtc/ion-web
     volumes:
-      - "./configs:/cert"
-      - "./docker/nginx.conf:/etc/nginx/conf.d/default.conf"
+      - "./docker/Caddyfile:/etc/Caddyfile"
     ports:
-      - 8080:443
+      - 80:80
+      - 8080:8080
+      - 8443:8443
     depends_on:
       - biz
+    environment:
+    - WWW_URL
+    - ADMIN_EMAIL
 
   sfu:
     # build:
@@ -36,10 +40,6 @@ services:
     command: "-c /configs/biz.toml"
     volumes:
       - "./docker/biz.toml:/configs/biz.toml"
-      - "./configs/cert.pem:/configs/cert.pem"
-      - "./configs/key.pem:/configs/key.pem"
-    ports:
-      - 8443:8443 # websocket
     depends_on:
       - nats
       - etcd

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,0 +1,15 @@
+* {
+  tls {$ADMIN_EMAIL}
+}
+
+{$WWW_URL}:8080 {
+  root /app/demo/dist
+}
+
+{$WWW_URL}:8443 {
+  proxy / biz:8443 {
+    transparent
+    websocket
+    header_upstream Sec-WebSocket-Protocol {>Sec-WebSocket-Protocol}
+  }
+}

--- a/docker/biz.toml
+++ b/docker/biz.toml
@@ -19,9 +19,6 @@ addrs = ["etcd:2379"]
 #listen ip port
 host = "0.0.0.0"
 port = "8443"
-cert= "/configs/cert.pem"
-key= "/configs/key.pem"
-
 
 [nats]
 url = "nats://nats:4222"

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.0-buster-slim as builder
+FROM node:12.16.0-buster-slim
 
 WORKDIR /app
 COPY ./sdk/js/package.json ./
@@ -14,6 +14,12 @@ COPY ./sdk/js ./
 WORKDIR /app/demo
 RUN npm run build
 
-FROM nginx:1.17
-WORKDIR /dist
-COPY --from=builder /app/demo/dist .
+RUN apt-get update && apt-get install -y \
+    curl \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV ENABLE_TELEMETRY="false"
+RUN curl https://getcaddy.com | bash -s personal
+
+ENTRYPOINT ["/usr/local/bin/caddy"]
+CMD ["--conf", "/etc/Caddyfile", "--log", "stdout", "--agree=true"]

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/at-wat/ebml-go v0.9.2
-	github.com/cloudwebrtc/go-protoo v0.0.0-20200226145235-c53bf45a00f9
+	github.com/cloudwebrtc/go-protoo v0.0.0-20200324091126-61fe57ffd18f
 	github.com/cloudwebrtc/nats-protoo v0.0.0-20200226142647-79046db44f55
 	github.com/coreos/etcd v3.3.18+incompatible // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/cheekybits/genny v1.0.0/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wX
 github.com/chuckpreslar/emission v0.0.0-20170206194824-a7ddd980baf9 h1:xz6Nv3zcwO2Lila35hcb0QloCQsc38Al13RNEzWRpX4=
 github.com/chuckpreslar/emission v0.0.0-20170206194824-a7ddd980baf9/go.mod h1:2wSM9zJkl1UQEFZgSd68NfCgRz1VL1jzy/RjCg+ULrs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudwebrtc/go-protoo v0.0.0-20200226145235-c53bf45a00f9 h1:PCw+25vDoh6KnxyZcO7V+rDGr+PvMiPieldeELaGFhg=
-github.com/cloudwebrtc/go-protoo v0.0.0-20200226145235-c53bf45a00f9/go.mod h1:Q0DiItmsD5iCBdeID9Xu03ok8bemc78XJ+0rYATQbuQ=
+github.com/cloudwebrtc/go-protoo v0.0.0-20200324091126-61fe57ffd18f h1:I9FnOOvegGTvlT2FUuh8skmkCfusD5jfGVI623l+Evo=
+github.com/cloudwebrtc/go-protoo v0.0.0-20200324091126-61fe57ffd18f/go.mod h1:Q0DiItmsD5iCBdeID9Xu03ok8bemc78XJ+0rYATQbuQ=
 github.com/cloudwebrtc/nats-protoo v0.0.0-20200226142647-79046db44f55 h1:HckVH3N4Cz/rY4x1Whmk67KbTglt1zPbIVyv5hs+s+g=
 github.com/cloudwebrtc/nats-protoo v0.0.0-20200226142647-79046db44f55/go.mod h1:GChOgYiUBBZTCzjSPbPCDIQCAtScaaJmvb41Vw83TLQ=
 github.com/coreos/bbolt v1.3.2 h1:wZwiHHUieZCquLkDL0B8UhzreNWsPHooDAG3q34zk0s=

--- a/sdk/js/src/Client.js
+++ b/sdk/js/src/Client.js
@@ -289,7 +289,8 @@ export default class Client extends EventEmitter {
 
     _getProtooUrl(pid) {
         const hostname = window.location.hostname;
-        let url = `wss://${hostname}:${this._port}/ws?peer=${pid}`;
+        const websocketProtocol = location.protocol === 'https:' ? 'wss' : 'ws'
+        let url = `${websocketProtocol}://${hostname}:${this._port}/ws?peer=${pid}`;
         return url;
     }
 


### PR DESCRIPTION
Don't merge until protoo-server is updated!

After this is done a user just needs to set
```
   - WWW_URL=
    - ADMIN_EMAIL=
```

And a valid HTTPS certificate will be generated on the fly. This means a user just needs to do `docker-compose up` with these two things set and everything will work out of the box!

I will work on updating the docs, and when this is done will reach out and we can start writing the social media posts :) thanks @adwpc @cloudwebrtc 