### PR TITLE
AVP Service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ example:
 	go build -o bin/service-watch $(GO_LDFLAGS) examples/watch/service-watch.go
 
 nodes:
+	go build -o bin/avp $(GO_LDFLAGS) cmd/avp/main.go
 	go build -o bin/biz $(GO_LDFLAGS) cmd/biz/main.go
 	go build -o bin/islb $(GO_LDFLAGS) cmd/islb/main.go
 	go build -o bin/sfu $(GO_LDFLAGS) cmd/sfu/main.go

--- a/cmd/avp/main.go
+++ b/cmd/avp/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"net/http"
+	_ "net/http/pprof"
+
+	conf "github.com/pion/ion/pkg/conf/avp"
+	"github.com/pion/ion/pkg/discovery"
+	"github.com/pion/ion/pkg/log"
+	"github.com/pion/ion/pkg/node/avp"
+	"github.com/pion/ion/pkg/rtc"
+)
+
+func init() {
+	var icePortStart, icePortEnd uint16
+
+	if len(conf.WebRTC.ICEPortRange) == 2 {
+		icePortStart = conf.WebRTC.ICEPortRange[0]
+		icePortEnd = conf.WebRTC.ICEPortRange[1]
+	}
+
+	log.Init(conf.Log.Level)
+	if err := rtc.Init(conf.Rtp.Port, conf.WebRTC.ICE, icePortStart, icePortEnd, "", ""); err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	log.Infof("--- Starting AVP Node ---")
+
+	if conf.Global.Pprof != "" {
+		go func() {
+			log.Infof("Start pprof on %s", conf.Global.Pprof)
+			http.ListenAndServe(conf.Global.Pprof, nil)
+		}()
+	}
+
+	serviceNode := discovery.NewServiceNode(conf.Etcd.Addrs, conf.Global.Dc)
+	serviceNode.RegisterNode("avp", "node-avp", "avp-channel-id")
+
+	rpcID := serviceNode.GetRPCChannel()
+	eventID := serviceNode.GetEventChannel()
+	avp.Init(conf.Global.Dc, serviceNode.NodeInfo().ID, rpcID, eventID, conf.Nats.URL)
+
+	serviceWatcher := discovery.NewServiceWatcher(conf.Etcd.Addrs, conf.Global.Dc)
+	serviceWatcher.WatchServiceNode("islb", avp.WatchServiceNodes)
+
+	select {}
+}

--- a/configs/avp.toml
+++ b/configs/avp.toml
@@ -1,0 +1,29 @@
+[global]
+pprof = ":6062"
+
+# data center id
+dc = "dc1"
+
+[webrtc]
+# if ion behind nat, uncomment one
+# ice = ["stun:stun.l.google.com:19302"]
+# ice = ["stun:stun.stunprotocol.org:3478"]
+
+# Range of ports that ion accepts WebRTC traffic on
+ephemeral-udp-port-range = []
+
+[rtp]
+# listen port
+port = 6667
+
+[log]
+level = "info"
+# level = "debug"
+
+[etcd]
+# ["ip:port", "ip:port"]
+addrs = ["127.0.0.1:2379"]
+
+[nats]
+url = "nats://127.0.0.1:4222"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,11 +19,12 @@ services:
 #     - ADMIN_EMAIL
 
   sfu:
-    # build:
-    #   dockerfile: ./docker/sfu.Dockerfile
-    #   context: .
+    build:
+      dockerfile: ./docker/sfu.Dockerfile
+      context: .
     command: "-c /configs/sfu.toml"
-    image: pionwebrtc/ion-sfu
+    restart: always
+    # image: pionwebrtc/ion-sfu
     volumes:
       - "./docker/sfu.toml:/configs/sfu.toml"
     ports:
@@ -32,23 +33,38 @@ services:
       - nats
       - etcd
 
-  biz:
+  avp:
     # build:
-    #   dockerfile: ./docker/biz.Dockerfile
+    #   dockerfile: ./docker/avp.Dockerfile
     #   context: .
-    image: pionwebrtc/ion-biz
+    # command: "-c /configs/avp.toml"
+    image: ion_avp:0.0.2
+    volumes:
+      - "./:/go/src/github.com/pion/ion"
+      - "./docker/avp.toml:/configs/avp.toml"
+    depends_on:
+      - nats
+      - etcd
+
+  biz:
+    build:
+      dockerfile: ./docker/biz.Dockerfile
+      context: .
+    # image: pionwebrtc/ion-biz
     command: "-c /configs/biz.toml"
     volumes:
       - "./docker/biz.toml:/configs/biz.toml"
+    ports:
+      - "8443:8443"
     depends_on:
       - nats
       - etcd
 
   islb:
-    # build:
-    #   dockerfile: ./docker/islb.Dockerfile
-    #   context: .
-    image: pionwebrtc/ion-islb
+    build:
+      dockerfile: ./docker/islb.Dockerfile
+      context: .
+    # image: pionwebrtc/ion-islb
     command: "-c /configs/islb.toml"
     volumes:
       - "./docker/islb.toml:/configs/islb.toml"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,22 @@
 version: '3.7'
 
 services:
-  web:
-    # build:
-    #   dockerfile: ./docker/web.Dockerfile
-    #   context: .
-    image: pionwebrtc/ion-web
-    volumes:
-      - "./docker/Caddyfile:/etc/Caddyfile"
-    ports:
-      - 80:80
-      - 8080:8080
-      - 8443:8443
-    depends_on:
-      - biz
-    environment:
-    - WWW_URL
-    - ADMIN_EMAIL
+#   web:
+#     # build:
+#     #   dockerfile: ./docker/web.Dockerfile
+#     #   context: .
+#     image: pionwebrtc/ion-web
+#     volumes:
+#       - "./docker/Caddyfile:/etc/Caddyfile"
+#     ports:
+#       - 80:80
+#       - 8080:8080
+#       - 8443:8443
+#     depends_on:
+#       - biz
+#     environment:
+#     - WWW_URL
+#     - ADMIN_EMAIL
 
   sfu:
     # build:

--- a/docker/avp.Dockerfile
+++ b/docker/avp.Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:1.13.7-stretch
+
+ENV GO111MODULE=on
+
+WORKDIR $GOPATH/src/github.com/pion/ion
+
+RUN echo $GOPATH/src/github.com/pion/ion
+
+COPY go.mod go.sum ./
+RUN cd $GOPATH/src/github.com/pion/ion && go mod download
+
+COPY . $GOPATH/src/github.com/pion/ion
+
+WORKDIR $GOPATH/src/github.com/pion/ion/cmd/avp
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /avp .
+
+# FROM alpine:3.9.5
+
+# RUN apk --no-cache add ca-certificates
+# COPY --from=0 /avp /usr/local/bin/avp
+
+# ENTRYPOINT ["/bin/bash"]
+RUN echo 'ping localhost > /dev/null &' > /bootstrap.sh
+RUN echo 'sleep infinity' >> /bootstrap.sh
+RUN chmod +x /bootstrap.sh
+
+CMD /bootstrap.sh

--- a/docker/avp.toml
+++ b/docker/avp.toml
@@ -4,9 +4,6 @@ pprof = ":6062"
 # data center id
 dc = "dc1"
 
-# internet ip
-addr = "127.0.0.1"
-
 [webrtc]
 ice = ["stun:stun.l.google.com:19302"]
 

--- a/docker/avp.toml
+++ b/docker/avp.toml
@@ -1,0 +1,26 @@
+[global]
+pprof = ":6062"
+
+# data center id
+dc = "dc1"
+
+# internet ip
+addr = "127.0.0.1"
+
+[webrtc]
+ice = ["stun:stun.l.google.com:19302"]
+
+[rtp]
+# listen port
+port = 6667
+
+[log]
+level = "info"
+# level = "debug"
+
+[etcd]
+# ["ip:port", "ip:port"]
+addrs = ["etcd:2379"]
+
+[nats]
+url = "nats://nats:4222"

--- a/pkg/conf/avp/conf.go
+++ b/pkg/conf/avp/conf.go
@@ -1,0 +1,108 @@
+package conf
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/spf13/viper"
+)
+
+var (
+	cfg    = config{}
+	Global = &cfg.Global
+	WebRTC = &cfg.WebRTC
+	Rtp    = &cfg.Rtp
+	Log    = &cfg.Log
+	Etcd   = &cfg.Etcd
+	Nats   = &cfg.Nats
+)
+
+func init() {
+	if !cfg.parse() {
+		showHelp()
+		os.Exit(-1)
+	}
+}
+
+type global struct {
+	Addr  string `mapstructure:"addr"`
+	Pprof string `mapstructure:"pprof"`
+	Dc    string `mapstructure:"dc"`
+	// TestIP []string `mapstructure:"testip"`
+}
+
+type log struct {
+	Level string `mapstructure:"level"`
+}
+
+type etcd struct {
+	Addrs []string `mapstructure:"addrs"`
+}
+
+type nats struct {
+	URL string `mapstructure:"url"`
+}
+
+type webrtc struct {
+	ICE          []string `mapstructure:"ice"`
+	ICEPortRange []uint16 `mapstructure:"ephemeral-udp-port-range"`
+}
+
+type rtp struct {
+	Port int `mapstructure:"port"`
+}
+
+type config struct {
+	Global  global `mapstructure:"global"`
+	WebRTC  webrtc `mapstructure:"webrtc"`
+	Rtp     rtp    `mapstructure:"rtp"`
+	Log     log    `mapstructure:"log"`
+	Etcd    etcd   `mapstructure:"etcd"`
+	Nats    nats   `mapstructure:"nats"`
+	CfgFile string
+}
+
+func showHelp() {
+	fmt.Printf("Usage:%s {params}\n", os.Args[0])
+	fmt.Println("      -c {config file}")
+	fmt.Println("      -h (show help info)")
+}
+
+func (c *config) load() bool {
+	_, err := os.Stat(c.CfgFile)
+	if err != nil {
+		return false
+	}
+
+	viper.SetConfigFile(c.CfgFile)
+	viper.SetConfigType("toml")
+
+	err = viper.ReadInConfig()
+	if err != nil {
+		fmt.Printf("config file %s read failed. %v\n", c.CfgFile, err)
+		return false
+	}
+	err = viper.GetViper().UnmarshalExact(c)
+	if err != nil {
+		fmt.Printf("config file %s loaded failed. %v\n", c.CfgFile, err)
+		return false
+	}
+	fmt.Printf("config %s load ok!\n", c.CfgFile)
+	return true
+}
+
+func (c *config) parse() bool {
+	flag.StringVar(&c.CfgFile, "c", "conf/conf.toml", "config file")
+	help := flag.Bool("h", false, "help info")
+	flag.Parse()
+	if !c.load() {
+		return false
+	}
+
+	if *help {
+		showHelp()
+		return false
+	}
+	return true
+}

--- a/pkg/node/avp/init.go
+++ b/pkg/node/avp/init.go
@@ -1,0 +1,65 @@
+package avp
+
+import (
+	nprotoo "github.com/cloudwebrtc/nats-protoo"
+	"github.com/pion/ion/pkg/discovery"
+	"github.com/pion/ion/pkg/log"
+)
+
+var (
+	dc          = "default"
+	nid         = "avp-unkown-node-id"
+	protoo      *nprotoo.NatsProtoo
+	rpcs        map[string]*nprotoo.Requestor
+	services    map[string]discovery.Node
+	broadcaster *nprotoo.Broadcaster
+)
+
+// Init func
+func Init(dcID, nodeID, rpcID, eventID, natsURL string) {
+	dc = dcID
+	nid = nodeID
+	protoo = nprotoo.NewNatsProtoo(natsURL)
+	rpcs = make(map[string]*nprotoo.Requestor)
+	services = make(map[string]discovery.Node)
+	broadcaster = protoo.NewBroadcaster(eventID)
+}
+
+// WatchServiceNodes .
+func WatchServiceNodes(service string, state discovery.NodeStateType, node discovery.Node) {
+	id := node.ID
+
+	if state == discovery.UP {
+		if _, found := services[id]; !found {
+			services[id] = node
+		}
+
+		service := node.Info["service"]
+		name := node.Info["name"]
+		log.Debugf("Service [%s] %s => %s", service, name, id)
+
+		_, found := rpcs[id]
+		if !found {
+			rpcID := discovery.GetRPCChannel(node)
+			eventID := discovery.GetEventChannel(node)
+
+			log.Infof("Create islb requestor: rpcID => [%s]", rpcID)
+			rpcs[id] = protoo.NewRequestor(rpcID)
+
+			log.Infof("handleIslbBroadCast: eventID => [%s]", eventID)
+			protoo.OnBroadcast(eventID, handleIslbBroadCast)
+		}
+
+	} else if state == discovery.DOWN {
+		if _, found := services[id]; found {
+			delete(services, id)
+		}
+	}
+}
+
+// Close func
+func Close() {
+	if protoo != nil {
+		protoo.Close()
+	}
+}

--- a/pkg/node/avp/internal.go
+++ b/pkg/node/avp/internal.go
@@ -1,0 +1,199 @@
+package avp
+
+import (
+	"time"
+
+	nprotoo "github.com/cloudwebrtc/nats-protoo"
+	"github.com/pion/ion/pkg/discovery"
+	"github.com/pion/ion/pkg/log"
+	"github.com/pion/ion/pkg/proto"
+	transport "github.com/pion/ion/pkg/rtc/transport"
+	"github.com/pion/ion/pkg/util"
+	"github.com/pion/rtcp"
+	"github.com/pion/webrtc/v2"
+	"github.com/pion/webrtc/v2/pkg/media"
+	"github.com/pion/webrtc/v2/pkg/media/ivfwriter"
+	"github.com/pion/webrtc/v2/pkg/media/oggwriter"
+)
+
+// strToMap make string value to map
+func strToMap(msg map[string]interface{}, key string) {
+	val := util.Val(msg, key)
+	if val != "" {
+		m := util.Unmarshal(val)
+		msg[key] = m
+	}
+}
+
+func getRPCForIslb() (*nprotoo.Requestor, bool) {
+	for _, item := range services {
+		if item.Info["service"] == "islb" {
+			id := item.Info["id"]
+			rpc, found := rpcs[id]
+			if !found {
+				rpcID := discovery.GetRPCChannel(item)
+				log.Infof("Create rpc [%s] for islb", rpcID)
+				rpc = protoo.NewRequestor(rpcID)
+				rpcs[id] = rpc
+			}
+			return rpc, true
+		}
+	}
+	log.Warnf("No islb node was found.")
+	return nil, false
+}
+
+func getRPCForSFU(mid string) (string, *nprotoo.Requestor, *nprotoo.Error) {
+	islb, found := getRPCForIslb()
+	if !found {
+		return "", nil, util.NewNpError(500, "Not found any node for islb.")
+	}
+	result, err := islb.SyncRequest(proto.IslbFindService, util.Map("service", "sfu", "mid", mid))
+	if err != nil {
+		return "", nil, err
+	}
+
+	log.Infof("SFU result => %v", result)
+	rpcID := result["rpc-id"].(string)
+	nodeID := result["id"].(string)
+	rpc, found := rpcs[rpcID]
+	if !found {
+		rpc = protoo.NewRequestor(rpcID)
+		rpcs[rpcID] = rpc
+	}
+	return nodeID, rpc, nil
+}
+
+func saveToDisk(i media.Writer, track *webrtc.Track) {
+	defer func() {
+		if err := i.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	for {
+		rtpPacket, err := track.ReadRTP()
+		if err != nil {
+			panic(err)
+		}
+		if err := i.WriteRTP(rtpPacket); err != nil {
+			panic(err)
+		}
+	}
+}
+
+// broadcast msg from islb
+func handleIslbBroadCast(msg map[string]interface{}, subj string) {
+	go func(msg map[string]interface{}) {
+		method := util.Val(msg, "method")
+		data := msg["data"].(map[string]interface{})
+		log.Infof("OnIslbBroadcast: method=%s, data=%v", method, data)
+
+		//make signal.Notify send "info" as a json object, otherwise is a string (:
+		strToMap(data, "info")
+		switch method {
+		case proto.IslbOnStreamAdd:
+			handleOnStreamAdd(data)
+			// case proto.IslbOnStreamRemove:
+			// 	TODO
+		}
+	}(msg)
+}
+
+func getAnswerForOffer(uid string, rid string, mid string, offer webrtc.SessionDescription) (webrtc.SessionDescription, *nprotoo.Error) {
+	islb, found := getRPCForIslb()
+	if !found {
+		return webrtc.SessionDescription{}, util.NewNpError(500, "Not found any node for islb.")
+	}
+
+	mediaInfo, err := islb.SyncRequest(proto.IslbGetMediaInfo, util.Map("rid", rid, "mid", mid))
+	if err != nil {
+		return webrtc.SessionDescription{}, util.NewNpError(err.Code, err.Reason)
+	}
+
+	_, sfu, err := getRPCForSFU(mid)
+
+	if err != nil {
+		log.Warnf("stream-add: sfu node not found, reject: %d => %s", err.Code, err.Reason)
+		return webrtc.SessionDescription{}, util.NewNpError(err.Code, err.Reason)
+	}
+
+	log.Infof("Client Subscribe => uid: %s mid: %s tracks: %v", uid, mid, mediaInfo["tracks"])
+	result, err := sfu.SyncRequest(proto.ClientSubscribe, util.Map("uid", uid, "mid", mid, "tracks", mediaInfo["tracks"], "jsep", offer))
+
+	if err != nil {
+		log.Warnf("stream-add: error subscribing to stream, reject: %d => %s", err.Code, err.Reason)
+		return webrtc.SessionDescription{}, util.NewNpError(err.Code, err.Reason)
+	}
+
+	jsep := result["jsep"].(map[string]interface{})
+
+	if jsep == nil {
+		return webrtc.SessionDescription{}, util.NewNpError(415, "stream-add: jsep invaild.")
+	}
+
+	sdp := util.Val(jsep, "sdp")
+	return webrtc.SessionDescription{Type: webrtc.SDPTypeAnswer, SDP: sdp}, nil
+}
+
+func handleOnStreamAdd(data map[string]interface{}) *nprotoo.Error {
+	uid := util.Val(data, "uid")
+	rid := util.Val(data, "rid")
+	mid := util.Val(data, "mid")
+
+	log.Infof("IslbOnStreamAdd: uid=%s, mid=%s", uid, mid)
+
+	rtcOptions := make(map[string]interface{})
+	rtcOptions["subscribe"] = "true"
+
+	sub := transport.NewWebRTCTransport(mid, rtcOptions)
+	offer, err := sub.Offer()
+
+	if err != nil {
+		log.Warnf("Error creating offer, reject: %d => %s", 415, err)
+		return util.NewNpError(415, "steam-add: error creating offer")
+	}
+
+	answer, nerr := getAnswerForOffer(uid, rid, mid, offer)
+
+	if nerr != nil {
+		log.Warnf("Error receiving answer, reject: %d => %s", 415, nerr)
+		return util.NewNpError(415, "steam-add: error receiving answer")
+	}
+
+	sub.SetRemoteSDP(answer)
+
+	oggFile, err := oggwriter.New("output.ogg", 48000, 2)
+	if err != nil {
+		panic(err)
+	}
+	ivfFile, err := ivfwriter.New("output.ivf")
+	if err != nil {
+		panic(err)
+	}
+
+	sub.OnTrack(func(track *webrtc.Track, receiver *webrtc.RTPReceiver) {
+		// Send a PLI on an interval so that the publisher is pushing a keyframe every rtcpPLIInterval
+		go func() {
+			ticker := time.NewTicker(time.Second * 3)
+			for range ticker.C {
+				errSend := sub.WriteRTCP(&rtcp.PictureLossIndication{MediaSSRC: track.SSRC()})
+				if errSend != nil {
+					log.Warnf("Error sending RTCP")
+				}
+			}
+		}()
+
+		codec := track.Codec()
+		log.Infof("Codec %s", codec)
+		if codec.Name == webrtc.Opus {
+			log.Infof("Got Opus track, saving to disk as output.opus (48 kHz, 2 channels)")
+			saveToDisk(oggFile, track)
+		} else if codec.Name == webrtc.VP8 {
+			log.Infof("Got VP8 track, saving to disk as output.ivf")
+			saveToDisk(ivfFile, track)
+		}
+	})
+
+	return nil
+}

--- a/pkg/rtc/transport/webrtctransport.go
+++ b/pkg/rtc/transport/webrtctransport.go
@@ -229,6 +229,11 @@ func (w *WebRTCTransport) SetRemoteSDP(sdp webrtc.SessionDescription) error {
 	return w.pc.SetRemoteDescription(sdp)
 }
 
+// OnTrack handler
+func (w *WebRTCTransport) OnTrack(f func(*webrtc.Track, *webrtc.RTPReceiver)) {
+	w.pc.OnTrack(f)
+}
+
 // AddTrack add track to pc
 func (w *WebRTCTransport) AddTrack(ssrc uint32, pt uint8, streamID string, trackID string) (*webrtc.Track, error) {
 	if w.pc == nil {


### PR DESCRIPTION
Initial commit for an AVP service. This is a WIP but would like feedback on the general approach. This implements simple stream recording logic. Eventually i would like to generalize it to support arbitrary processing pipelines. Please let me know if you have any suggestions!

Right now, the AVP process listens to ISLB for new streams, then subscribes to them from the appropriate SFU. In the current implementation, the service only consumes. I would like to extend it to potentially replace the streams in the SFU too, so processed streams can be published to clients.