### PR TITLE
Properly cleanup client disconnects

### DIFF
--- a/pkg/node/biz/client.go
+++ b/pkg/node/biz/client.go
@@ -76,8 +76,12 @@ func handleSFUBroadCast(msg map[string]interface{}, subj string) {
 		switch method {
 		case proto.SFUTrickleICE:
 			signal.NotifyAllWithoutID(rid, uid, proto.ClientOnStreamAdd, data)
-			//case proto.IslbOnStreamRemove:
-			//	signal.NotifyAllWithoutID(rid, uid, proto.ClientOnStreamRemove, data)
+		case proto.SFUStreamRemove:
+			mid := util.Val(data, "mid")
+			islb, found := getRPCForIslb()
+			if found {
+				islb.AsyncRequest(proto.IslbOnStreamRemove, util.Map("mid", mid))
+			}
 		}
 	}(msg)
 }

--- a/pkg/node/islb/internal.go
+++ b/pkg/node/islb/internal.go
@@ -194,6 +194,8 @@ func streamRemove(data map[string]interface{}) (map[string]interface{}, *nprotoo
 	if mid == "" {
 		uid := util.Val(data, "uid")
 		mkey = proto.BuildMediaInfoKey(dc, rid, "*", uid)
+	} else if rid == "" {
+		mkey = proto.BuildMediaInfoKey(dc, "*", "*", mid)
 	} else {
 		mkey = proto.BuildMediaInfoKey(dc, rid, "*", mid)
 	}


### PR DESCRIPTION
Fixes an issue where the redis store wasn't being correctly cleaned up on disconnects. This delegates cleanup to the islb.