### PR TITLE
fix bug when tracks is null

### DIFF
--- a/sdk/flutter/lib/src/client.dart
+++ b/sdk/flutter/lib/src/client.dart
@@ -181,7 +181,7 @@ class Client extends EventEmitter {
     logger.debug('subscribe rid => $rid, mid => $mid,  tracks => ${tracks.toString()}');
     Completer completer = new Completer<Stream>();
     var codec = "";
-    tracks.forEach((trackID,trackInfoArr) async {
+    tracks?.forEach((trackID,trackInfoArr) async {
         logger.debug('trackInfoArr=$trackInfoArr');
 
         for(var i=0; i<trackInfoArr.length; i++){


### PR DESCRIPTION
#### Description
Bug when running `flutter run -d macOS`
```
[ERROR:flutter/lib/ui/ui_dart_state.cc(157)] Unhandled Exception: NoSuchMethodError: The method 'forEach' was called on null.
Receiver: null
Tried calling: forEach(Closure: (dynamic, dynamic) => Future<Null>)
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:53:5)
#1      Client.subscribe (package:flutter_ion/src/client.dart:184:12)
#2      _MeetingPageState.init.<anonymous closure> (package:pion_sfu_example/page/meeting_page.dart:51:33)
#3      EventEmitter.callback (package:events2/src/event_emitter.dart:38:15)
```
#### Reference issue


