### PR TITLE
Add docker volume for Caddy config. 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     image: pionwebrtc/ion-web:0.1.0
     volumes:
       - "./docker/Caddyfile:/etc/Caddyfile"
+      - "caddy:/root/.caddy"
     ports:
       - 80:80
       - 8080:8080
@@ -83,3 +84,6 @@ services:
 
   redis:
     image: redis:5.0.7
+
+volumes:
+  caddy:


### PR DESCRIPTION
#### Description
Allows reuse of LE generated certs and avoids hitting the LE rate limit when restarting web container.
