### PR TITLE
Docker hosting updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ Welcome contributing to ion!
 ## How to use
 
 ### Local Deployment
-#### 1. clone
+#### 1. Clone
 ```
 git clone https://github.com/pion/ion
 ```
 
-#### 2. run
+#### 2. Run
 Firstly pull images. Skip this command if you want build images locally
 ```
 docker-compose pull
@@ -83,7 +83,7 @@ docker-compose pull
 docker-compose up
 ```
 
-#### 3. chat
+#### 3. Chat!
 Open this url with chrome
 
 ```
@@ -92,31 +92,45 @@ http://localhost:8080
 
 ### Online Deployment
 
-#### 1. clone
+#### 1. Clone
 
 ```
 git clone https://github.com/pion/ion
 ```
 
-#### 2. set env
+#### 2. Set Env
 
 ```
 export WWW_URL=yourdomain
 export ADMIN_EMAIL=yourname@yourdomain
 ```
 
-#### 3. run
+#### 3. Configure docker compose
+
+Enable production ports and Caddy file for web service in `docker-compose.yml`.
+
+#### 4. Expose Ports
+
+Ensure the following ports are exposed or forwarded.
+
+```
+80/tcp
+443/tcp
+5000-5200/udp
+```
+
+#### 5. Run
 
 ```
 docker-compose up
 ```
 
-#### 3. chat
+#### 6. Chat!
 
 Open this url with chrome
 
 ```
-https://yourdomain:8080
+https://yourdomain
 ```
 
 ### Docker Tips

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,7 @@ services:
       - "./docker/Caddyfile:/etc/Caddyfile"
     ports:
       - 80:80
-      - 8080:8080
-      - 8443:8443
+      - 443:443
     depends_on:
       - biz
     environment:
@@ -52,6 +51,8 @@ services:
     command: "-c /configs/biz.toml"
     volumes:
       - "./docker/biz.toml:/configs/biz.toml"
+    ports:
+      - 8443:8443
     depends_on:
       - nats
       - etcd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,16 @@ services:
     #   context: .
     image: pionwebrtc/ion-web:0.1.0
     volumes:
-      - "./docker/Caddyfile:/etc/Caddyfile"
+      # Uncomment for production
+      # - "./docker/Caddyfile:/etc/caddy/Caddyfile"
+      # Dev caddyfile
+      - "./docker/local.Caddyfile:/etc/caddy/Caddyfile"
+      - "caddy:/root/.caddy/"
     ports:
-      - 80:80
-      - 443:443
+      # Prod ports
+      # - 80:80
+      # - 443:443
+      - 8080:8080
     depends_on:
       - biz
     environment:

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,13 +1,8 @@
-* {
-  tls {$ADMIN_EMAIL}
-}
-
-{$WWW_URL}:8080 {
+{$WWW_URL} {
   root /app/demo/dist
-}
+  tls {$ADMIN_EMAIL}
 
-{$WWW_URL}:8443 {
-  proxy / biz:8443 {
+  proxy /ws biz:8443 {
     transparent
     websocket
     header_upstream Sec-WebSocket-Protocol {>Sec-WebSocket-Protocol}

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,10 +1,9 @@
 {$WWW_URL} {
-  root /app/demo/dist
+  root * /app/demo/dist
+  file_server
   tls {$ADMIN_EMAIL}
 
-  proxy /ws biz:8443 {
-    transparent
-    websocket
-    header_upstream Sec-WebSocket-Protocol {>Sec-WebSocket-Protocol}
+  reverse_proxy /ws biz:8443 {
+    header_up Sec-WebSocket-Protocol {>Sec-WebSocket-Protocol}
   }
 }

--- a/docker/local.Caddyfile
+++ b/docker/local.Caddyfile
@@ -1,0 +1,8 @@
+http://localhost:8080 {
+  root * /app/demo/dist
+  file_server
+
+  reverse_proxy /ws biz:8443 {
+    header_up Sec-WebSocket-Protocol {>Sec-WebSocket-Protocol}
+  }
+}

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -1,22 +1,21 @@
-FROM alpine
+FROM node:lts-alpine
+
+WORKDIR /app
+COPY ./sdk/js/package.json ./
+RUN npm install
+
+COPY ./sdk/js/demo/package.json ./demo/
+WORKDIR /app/demo
+RUN npm install
+
+WORKDIR /app
+COPY ./sdk/js ./
+
+WORKDIR /app/demo
+RUN npm run build
 
 ENV ENABLE_TELEMETRY="false"
-WORKDIR /usr/src/ion
 
-COPY ./sdk/js /usr/src/ion
-RUN apk add --no-cache --update nodejs npm \
-  && mkdir -p /app/demo \
-  && npm install \
-  && cd demo  \
-  && npm install \
-  && npm run build \
-  && mv dist /app/demo \
-  && rm -rf /usr/src/ion /root/.npm /tmp/* \
-  && apk del --no-cache nodejs npm
-
-RUN apk add --no-cache --update curl bash \
-    && curl https://getcaddy.com | bash -s personal \
-    && apk del --no-cache curl bash
-
-ENTRYPOINT ["/usr/local/bin/caddy"]
-CMD ["--conf", "/etc/Caddyfile", "--log", "stdout", "--agree=true"]
+FROM caddy:2.0.0-rc.3-alpine
+RUN mkdir -p /app/demo
+COPY --from=0 /app/demo/dist /app/demo/dist

--- a/sdk/flutter/example/lib/helper/ion_helper.dart
+++ b/sdk/flutter/example/lib/helper/ion_helper.dart
@@ -11,7 +11,7 @@ class IonHelper extends EventEmitter {
 
   connect(host) async {
     if (_client == null) {
-      var url = 'https://$host:8443/ws';
+      var url = 'https://$host/ws';
       _client = Client(url);
 
       _client.on('transport-open', () {

--- a/sdk/js/src/Client.js
+++ b/sdk/js/src/Client.js
@@ -18,7 +18,6 @@ export default class Client extends EventEmitter {
 
     constructor() {
         super();
-        this._port = 8443;
         this._uid = uuidv4();
         this._pcs = new Map();
         this._streams = new Map();
@@ -299,9 +298,9 @@ export default class Client extends EventEmitter {
     }
 
     _getProtooUrl(pid) {
-        const hostname = window.location.hostname;
+        const host = window.location.host;
         const websocketProtocol = location.protocol === 'https:' ? 'wss' : 'ws'
-        let url = `${websocketProtocol}://${hostname}:${this._port}/ws?peer=${pid}`;
+        let url = `${websocketProtocol}://${host}/ws?peer=${pid}`;
         return url;
     }
 


### PR DESCRIPTION
Expose Biz websocket under a path on web, not a separate port. Switch to standard web ports for http/https. This simplifies prod hosting as only the two common ports must be exposed for the web service.

For local dev the 8443 websocket port is routed directly to the biz container. This port should not be exposed in production / external hosting.

This required some minor client updates. The changes made here will use the host:port combination that the page is currently served on to request the /ws path. A better long term solution would be to provide these as defaults but allow the clients to specify an override url for the biz ws location.

The web dockerfile was reworked to use multistage builds. I grabbed the code from the previous version, before space reduction, and simply updated to use pre-built docker images for node and  caddy server. Overall the image size should be similar, but with the benefit of docker layer caching for node builds.

Additionally the Caddyfile was update to version 2.0 to support the versions available from dockerhub. The Caddy files have been split into a local and remote version with http port 8080 for localhost. The docker-compose file has both with remote currently commented out. For prod, port 8080 should not be exposed publicly.

This should fit most cases, but could use some feedback on how people are hosting remote and locally for dev. 

Fixes #75 