### PR TITLE
Fix transport.GetInt(): case nil and delete the unreachable code.

### DIFF
--- a/pkg/rtc/transport/util.go
+++ b/pkg/rtc/transport/util.go
@@ -39,6 +39,8 @@ func GetInt(m map[string]interface{}, k string) (int, error) {
 	val, ok := m[k]
 	if ok {
 		switch val.(type) {
+		case nil:
+			return 0, errors.New("value is nil")
 		case string:
 			i, err := strconv.ParseInt(val.(string), 10, 64)
 			if err != nil {
@@ -49,10 +51,6 @@ func GetInt(m map[string]interface{}, k string) (int, error) {
 			return int(val.(float64)), nil
 		default:
 			return int(reflect.ValueOf(val).Int()), nil
-		}
-		n, ok := val.(int)
-		if ok {
-			return n, nil
 		}
 	}
 	return 0, errors.New("inavlid key or value type")


### PR DESCRIPTION
Fix transport.GetInt(): case nil and delete the unreachable code.
To reproduce the scene: if bandwidth of SDP is not set by client, the SFU server will crash.
