### PR TITLE
handlePanics from the websocket

### DIFF
--- a/pkg/signal/handle.go
+++ b/pkg/signal/handle.go
@@ -78,6 +78,13 @@ func in(transport *transport.WebSocketTransport, request *http.Request) {
 		log.Infof("signal.in handleClose => peer (%s) ", peer.ID())
 	}
 
+	handlePanic := func(a interface{}, b interface{}, err error) {
+		if err != nil {
+			log.Errorf("Websocket sent us for a panic: %s", err)
+		}
+	}
+
+	transport.RecoverWith(handlePanic)
 	peer.On("request", handleRequest)
 	peer.On("notification", handleNotification)
 	peer.On("close", handleClose)


### PR DESCRIPTION
#### Description
The `WebSocketTransport` is sent into a panic when it receives invalid JSON (as seen on #142 ). Alternatively this error handling could be put in the `go-protoo` package.

https://github.com/cloudwebrtc/go-protoo/blob/61fe57ffd18f60ff69cc4bd53bb0455d3fac74be/peer/peer.go#L96-L109
 
#### Reference issue
Fixes #142 
