### PR TITLE
Fix buffer memory leak on plugin close.

### DIFF
--- a/pkg/rtc/plugins/buffer.go
+++ b/pkg/rtc/plugins/buffer.go
@@ -173,10 +173,17 @@ func (b *Buffer) FindPacket(sn uint16) *rtp.Packet {
 	return b.pktBuffer[sn]
 }
 
-// Stop stop buffer
+// Stop buffer
 func (b *Buffer) Stop() {
 	b.stop = true
 	close(b.rtcpCh)
+	b.clear()
+}
+
+func (b *Buffer) clear() {
+	for i := range b.pktBuffer {
+		b.pktBuffer[i] = nil
+	}
 }
 
 // GetPayloadType get payloadtype

--- a/pkg/rtc/plugins/jitterbuffer.go
+++ b/pkg/rtc/plugins/jitterbuffer.go
@@ -267,6 +267,7 @@ func (j *JitterBuffer) Stop() {
 	for _, buffer := range j.buffers {
 		buffer.Stop()
 	}
+	j.buffers = nil
 }
 
 // Stat get stat from buffers


### PR DESCRIPTION
Really all that is needed to fix this is the change in jitterbuffer. Adding the self-empty on buffer close will protect from other unintentional leaks in the future.
