### PR TITLE
Remove assert contrip pre-push

### DIFF
--- a/.github/hooks/pre-push.sh
+++ b/.github/hooks/pre-push.sh
@@ -1,7 +1,3 @@
 #!/bin/sh
 
-set -e
-
-.github/assert-contributors.sh
-
 exit 0


### PR DESCRIPTION
File was still references in pre-push commit hook
