### PR TITLE
WIP: Register payload types for firefox codecs

### DIFF
--- a/pkg/rtc/transport/webrtctransport.go
+++ b/pkg/rtc/transport/webrtctransport.go
@@ -69,6 +69,8 @@ type WebRTCTransport struct {
 func (w *WebRTCTransport) init(options map[string]interface{}) error {
 	w.mediaEngine = webrtc.MediaEngine{}
 	w.mediaEngine.RegisterCodec(webrtc.NewRTPOpusCodec(webrtc.DefaultPayloadTypeOpus, 48000))
+	// Firfox
+	w.mediaEngine.RegisterCodec(webrtc.NewRTPOpusCodec(109, 48000))
 
 	rtcpfb := []webrtc.RTCPFeedback{
 		webrtc.RTCPFeedback{
@@ -106,8 +108,12 @@ func (w *WebRTCTransport) init(options map[string]interface{}) error {
 			w.mediaEngine.RegisterCodec(webrtc.NewRTPH264CodecExt(webrtc.DefaultPayloadTypeH264, 90000, rtcpfb, IOSH264Fmtp))
 		} else if codec == webrtc.VP8 {
 			w.mediaEngine.RegisterCodec(webrtc.NewRTPVP8CodecExt(webrtc.DefaultPayloadTypeVP8, 90000, rtcpfb, ""))
+			// Firefox vp8
+			w.mediaEngine.RegisterCodec(webrtc.NewRTPVP8CodecExt(120, 90000, rtcpfb, ""))
 		} else if codec == webrtc.VP9 {
 			w.mediaEngine.RegisterCodec(webrtc.NewRTPVP9Codec(webrtc.DefaultPayloadTypeVP9, 90000))
+			// Firefox vp9
+			w.mediaEngine.RegisterCodec(webrtc.NewRTPVP9Codec(121, 90000))
 		} else {
 			w.mediaEngine.RegisterCodec(webrtc.NewRTPH264CodecExt(webrtc.DefaultPayloadTypeH264, 90000, rtcpfb, IOSH264Fmtp))
 		}
@@ -115,6 +121,9 @@ func (w *WebRTCTransport) init(options map[string]interface{}) error {
 		w.mediaEngine.RegisterCodec(webrtc.NewRTPH264CodecExt(webrtc.DefaultPayloadTypeH264, 90000, rtcpfb, IOSH264Fmtp))
 		w.mediaEngine.RegisterCodec(webrtc.NewRTPVP8CodecExt(webrtc.DefaultPayloadTypeVP8, 90000, rtcpfb, ""))
 		w.mediaEngine.RegisterCodec(webrtc.NewRTPVP9Codec(webrtc.DefaultPayloadTypeVP9, 90000))
+		// Firefox
+		w.mediaEngine.RegisterCodec(webrtc.NewRTPVP8CodecExt(120, 90000, rtcpfb, ""))
+		w.mediaEngine.RegisterCodec(webrtc.NewRTPVP9Codec(121, 90000))
 	}
 
 	if !dc {

--- a/pkg/rtc/transport/webrtctransport.go
+++ b/pkg/rtc/transport/webrtctransport.go
@@ -104,9 +104,7 @@ func (w *WebRTCTransport) init(options map[string]interface{}) error {
 	}
 
 	if publish {
-		if codec == webrtc.H264 {
-			w.mediaEngine.RegisterCodec(webrtc.NewRTPH264CodecExt(webrtc.DefaultPayloadTypeH264, 90000, rtcpfb, IOSH264Fmtp))
-		} else if codec == webrtc.VP8 {
+		if codec == webrtc.VP8 {
 			w.mediaEngine.RegisterCodec(webrtc.NewRTPVP8CodecExt(webrtc.DefaultPayloadTypeVP8, 90000, rtcpfb, ""))
 			// Firefox vp8
 			w.mediaEngine.RegisterCodec(webrtc.NewRTPVP8CodecExt(120, 90000, rtcpfb, ""))
@@ -115,7 +113,11 @@ func (w *WebRTCTransport) init(options map[string]interface{}) error {
 			// Firefox vp9
 			w.mediaEngine.RegisterCodec(webrtc.NewRTPVP9Codec(121, 90000))
 		} else {
+			// Default webrtc.H264
 			w.mediaEngine.RegisterCodec(webrtc.NewRTPH264CodecExt(webrtc.DefaultPayloadTypeH264, 90000, rtcpfb, IOSH264Fmtp))
+			// Firefox
+			w.mediaEngine.RegisterCodec(webrtc.NewRTPH264CodecExt(97, 90000, rtcpfb, "profile-level-id=42e01f;level-asymmetry-allowed=1"))
+			w.mediaEngine.RegisterCodec(webrtc.NewRTPH264CodecExt(126, 90000, rtcpfb, "profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1"))
 		}
 	} else {
 		w.mediaEngine.RegisterCodec(webrtc.NewRTPH264CodecExt(webrtc.DefaultPayloadTypeH264, 90000, rtcpfb, IOSH264Fmtp))
@@ -124,6 +126,8 @@ func (w *WebRTCTransport) init(options map[string]interface{}) error {
 		// Firefox
 		w.mediaEngine.RegisterCodec(webrtc.NewRTPVP8CodecExt(120, 90000, rtcpfb, ""))
 		w.mediaEngine.RegisterCodec(webrtc.NewRTPVP9Codec(121, 90000))
+		w.mediaEngine.RegisterCodec(webrtc.NewRTPH264CodecExt(97, 90000, rtcpfb, "profile-level-id=42e01f;level-asymmetry-allowed=1"))
+		w.mediaEngine.RegisterCodec(webrtc.NewRTPH264CodecExt(126, 90000, rtcpfb, "profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1"))
 	}
 
 	if !dc {


### PR DESCRIPTION
Firefox can use different payload types for the same codecs as chrome. Register the different payload type ids with our mediaengine. This is probably not the best long term solution, but for now it allows sending media from Firefox.


Without this fix on my firefox sfu prints error on every packet
```
sfu_1    | 2020-05-17 23:11:59.692 ERR WebRTCTransport.WriteRTP track==nil pkt.SSRC=4070277398
sfu_1    | 2020-05-17 23:11:59.713 ERR WebRTCTransport.WriteRTP track==nil pkt.SSRC=4070277398
sfu_1    | 2020-05-17 23:11:59.714 ERR WebRTCTransport.WriteRTP track==nil pkt.SSRC=4070277398
sfu_1    | 2020-05-17 23:11:59.733 ERR WebRTCTransport.WriteRTP track==nil pkt.SSRC=4070277398
sfu_1    | 2020-05-17 23:11:59.733 ERR WebRTCTransport.WriteRTP track==nil pkt.SSRC=4070277398

```

Tested with sending audio/video from desktop firefox to mobile chrome.
