### PR TITLE
Use UUID for MID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/coreos/etcd v3.3.18+incompatible // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/go-redis/redis/v7 v7.2.0
-	github.com/google/uuid v1.1.1 // indirect
+	github.com/google/uuid v1.1.1
 	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/klauspost/cpuid v1.2.3 // indirect
 	github.com/klauspost/reedsolomon v1.9.3 // indirect

--- a/pkg/db/redis_test.go
+++ b/pkg/db/redis_test.go
@@ -14,7 +14,7 @@ var (
 	node   = "sfu1"
 	room   = "room1"
 	uid    = "uuid-xxxxx-xxxxx-xxxxx-xxxxx"
-	mid    = uid + "#" + "ABCDEF"
+	mid    = "mid-xxxxx-xxxxx-xxxxx-xxxxx"
 	msid0  = "pion audio"
 	msid1  = "pion video"
 	track0 = proto.TrackInfo{Ssrc: 3694449886, Payload: 111, Type: "audio", ID: "aid0"}
@@ -26,7 +26,7 @@ var (
 	uikey = "info"
 	uinfo = `{"name": "Guest"}`
 
-	mkey = proto.BuildMediaInfoKey(dc, room, node, mid)
+	mkey = proto.BuildMediaInfoKey(dc, node, room, uid, mid)
 	ukey = proto.BuildUserInfoKey(dc, room, uid)
 )
 

--- a/pkg/db/redis_test.go
+++ b/pkg/db/redis_test.go
@@ -26,8 +26,18 @@ var (
 	uikey = "info"
 	uinfo = `{"name": "Guest"}`
 
-	mkey = proto.BuildMediaInfoKey(dc, node, room, uid, mid)
-	ukey = proto.BuildUserInfoKey(dc, room, uid)
+	mkey = proto.MediaInfo{
+		DC:  dc,
+		NID: node,
+		RID: room,
+		UID: uid,
+		MID: mid,
+	}.BuildKey()
+	ukey = proto.UserInfo{
+		DC:  dc,
+		RID: room,
+		UID: room,
+	}.BuildKey()
 )
 
 func init() {

--- a/pkg/node/biz/client.go
+++ b/pkg/node/biz/client.go
@@ -159,7 +159,7 @@ func unpublish(peer *signal.Peer, msg UnpublishMsg) (interface{}, *nprotoo.Error
 		return nil, err
 	}
 
-	_, err = sfu.SyncRequest(proto.ClientUnPublish, util.Map("mid", mid, "rid", rid))
+	_, err = sfu.SyncRequest(proto.ClientUnPublish, util.Map("mid", mid, "uid", uid, "rid", rid))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/node/sfu/internal.go
+++ b/pkg/node/sfu/internal.go
@@ -90,7 +90,13 @@ func publish(msg map[string]interface{}) (map[string]interface{}, *nprotoo.Error
 		return nil, util.NewNpError(415, "publish: transport.NewWebRTCTransport failed.")
 	}
 
-	key := proto.BuildMediaInfoKey(dc, nid, rid, uid, mid)
+	key := proto.MediaInfo{
+		DC:  dc,
+		NID: nid,
+		RID: rid,
+		UID: uid,
+		MID: mid,
+	}.BuildKey()
 	router := rtc.GetOrNewRouter(key)
 	go handleTrickle(router, pub)
 
@@ -150,7 +156,13 @@ func unpublish(msg map[string]interface{}) (map[string]interface{}, *nprotoo.Err
 	mid := util.Val(msg, "mid")
 	uid := util.Val(msg, "uid")
 	rid := util.Val(msg, "rid")
-	key := proto.BuildMediaInfoKey(dc, nid, rid, uid, mid)
+	key := proto.MediaInfo{
+		DC:  dc,
+		NID: nid,
+		RID: rid,
+		UID: uid,
+		MID: mid,
+	}.BuildKey()
 	router := rtc.GetOrNewRouter(key)
 	if router != nil {
 		router.Close()
@@ -167,7 +179,13 @@ func subscribe(msg map[string]interface{}) (map[string]interface{}, *nprotoo.Err
 	mid := util.Val(msg, "mid")
 	uid := util.Val(msg, "uid")
 	rid := util.Val(msg, "rid")
-	key := proto.BuildMediaInfoKey(dc, nid, rid, uid, mid)
+	key := proto.MediaInfo{
+		DC:  dc,
+		NID: nid,
+		RID: rid,
+		UID: uid,
+		MID: mid,
+	}.BuildKey()
 	router := rtc.GetOrNewRouter(key)
 	if router == nil {
 		return nil, util.NewNpError(404, "subscribe: Router not found!")

--- a/pkg/proto/proto.go
+++ b/pkg/proto/proto.go
@@ -47,7 +47,7 @@ const (
 
 /*
 media
-dc/room1/media/pub/${mid}
+dc/${nid}/${rid}/${uid}/media/pub/${mid}
 
 node1 origin
 node2 shadow
@@ -55,34 +55,31 @@ msid  [{ssrc: 1234, pt: 111, type:audio}]
 msid  [{ssrc: 5678, pt: 96, type:video}]
 */
 
-func BuildMediaInfoKey(dc string, rid string, nid string, mid string) string {
-	strs := []string{dc, rid, nid, "media", "pub", mid}
+func BuildMediaInfoKey(dc string, nid string, rid string, uid string, mid string) string {
+	strs := []string{dc, nid, rid, uid, "media", "pub", mid}
 	return strings.Join(strs, "/")
 }
 
 type MediaInfo struct {
 	DC  string //Data Center ID
-	RID string //Room ID
 	NID string //Node ID
-	MID string //Media ID
+	RID string //Room ID
 	UID string //User ID
+	MID string //Media ID
 }
 
-// dc1/room1/sfu-tU2GInE5Lfuc/media/pub/7e97c1e8-c80a-4c69-81b0-27efc83e6120#NYYQLV
+// ParseMediaInfo dc1/sfu-tU2GInE5Lfuc/7485294b-9815-4888-83a5-631e77445b67/room1/media/pub/7e97c1e8-c80a-4c69-81b0-27efc83e6120
 func ParseMediaInfo(key string) (*MediaInfo, error) {
 	var info MediaInfo
 	arr := strings.Split(key, "/")
-	if len(arr) != 6 {
+	if len(arr) != 7 {
 		return nil, fmt.Errorf("Can‘t parse mediainfo; [%s]", key)
 	}
 	info.DC = arr[0]
-	info.RID = arr[1]
-	info.NID = arr[2]
-	info.MID = arr[5]
-	arr = strings.Split(info.MID, "#")
-	if len(arr) == 2 {
-		info.UID = arr[0]
-	}
+	info.NID = arr[1]
+	info.RID = arr[2]
+	info.UID = arr[3]
+	info.MID = arr[6]
 	return &info, nil
 }
 
@@ -164,10 +161,6 @@ func UnmarshalTrackField(key string, value string) (string, *[]TrackInfo, error)
 	}
 	msid := strings.Split(key, "/")[1]
 	return msid, &tracks, nil
-}
-
-func GetUIDFromMID(mid string) string {
-	return strings.Split(mid, "#")[0]
 }
 
 func GetPubNodePath(rid, uid string) string {

--- a/pkg/proto/proto.go
+++ b/pkg/proto/proto.go
@@ -55,11 +55,6 @@ msid  [{ssrc: 1234, pt: 111, type:audio}]
 msid  [{ssrc: 5678, pt: 96, type:video}]
 */
 
-func BuildMediaInfoKey(dc string, nid string, rid string, uid string, mid string) string {
-	strs := []string{dc, nid, rid, uid, "media", "pub", mid}
-	return strings.Join(strs, "/")
-}
-
 type MediaInfo struct {
 	DC  string //Data Center ID
 	NID string //Node ID
@@ -68,7 +63,27 @@ type MediaInfo struct {
 	MID string //Media ID
 }
 
-// ParseMediaInfo dc1/sfu-tU2GInE5Lfuc/7485294b-9815-4888-83a5-631e77445b67/room1/media/pub/7e97c1e8-c80a-4c69-81b0-27efc83e6120
+func (m MediaInfo) BuildKey() string {
+	if m.DC == "" {
+		m.DC = "*"
+	}
+	if m.NID == "" {
+		m.NID = "*"
+	}
+	if m.RID == "" {
+		m.RID = "*"
+	}
+	if m.UID == "" {
+		m.UID = "*"
+	}
+	if m.MID == "" {
+		m.MID = "*"
+	}
+	strs := []string{m.DC, m.NID, m.RID, m.UID, "media", "pub", m.MID}
+	return strings.Join(strs, "/")
+}
+
+// Parse dc1/sfu-tU2GInE5Lfuc/7485294b-9815-4888-83a5-631e77445b67/room1/media/pub/7e97c1e8-c80a-4c69-81b0-27efc83e6120
 func ParseMediaInfo(key string) (*MediaInfo, error) {
 	var info MediaInfo
 	arr := strings.Split(key, "/")
@@ -89,15 +104,15 @@ user
 info {name: "Guest"}
 */
 
-func BuildUserInfoKey(dc string, rid string, uid string) string {
-	strs := []string{dc, rid, "user", "info", uid}
-	return strings.Join(strs, "/")
-}
-
 type UserInfo struct {
 	DC  string
 	RID string
 	UID string
+}
+
+func (u UserInfo) BuildKey() string {
+	strs := []string{u.DC, u.RID, "user", "info", u.UID}
+	return strings.Join(strs, "/")
 }
 
 func ParseUserInfo(key string) (*UserInfo, error) {

--- a/pkg/proto/proto_test.go
+++ b/pkg/proto/proto_test.go
@@ -6,9 +6,9 @@ import (
 )
 
 func TestKeyBuildAndParse(t *testing.T) {
-	key := BuildMediaInfoKey("dc1", "room1", "sfu1", "mid1")
+	key := BuildMediaInfoKey("dc1", "sfu1", "room1", "uid1", "mid1")
 
-	if key != "dc1/room1/sfu1/media/pub/mid1" {
+	if key != "dc1/sfu1/room1/uid1/media/pub/mid1" {
 		t.Error("MediaInfo key not match")
 	}
 	fmt.Println(key)

--- a/pkg/proto/proto_test.go
+++ b/pkg/proto/proto_test.go
@@ -6,7 +6,13 @@ import (
 )
 
 func TestKeyBuildAndParse(t *testing.T) {
-	key := BuildMediaInfoKey("dc1", "sfu1", "room1", "uid1", "mid1")
+	key := MediaInfo{
+		DC:  "dc1",
+		NID: "sfu1",
+		RID: "room1",
+		UID: "uid1",
+		MID: "mid1",
+	}.BuildKey()
 
 	if key != "dc1/sfu1/room1/uid1/media/pub/mid1" {
 		t.Error("MediaInfo key not match")
@@ -19,7 +25,11 @@ func TestKeyBuildAndParse(t *testing.T) {
 	}
 	fmt.Println(minfo)
 
-	key = BuildUserInfoKey("dc1", "room1", "user1")
+	key = UserInfo{
+		DC:  "dc1",
+		RID: "room1",
+		UID: "user1",
+	}.BuildKey()
 	if key != "dc1/room1/user/info/user1" {
 		t.Error("UserInfo key not match")
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"encoding/json"
-	"fmt"
 	"math/rand"
 	"net"
 	"runtime"
@@ -22,10 +21,6 @@ import (
 var (
 	localIPPrefix = [...]string{"192.168", "10.0", "169.254", "172.16"}
 )
-
-func GetMID(uid string) string {
-	return fmt.Sprintf("%s#%s", uid, RandStr(6))
-}
 
 func IsLocalIP(ip string) bool {
 	for i := 0; i < len(localIPPrefix); i++ {


### PR DESCRIPTION
Changes MID to use its own UUID so it has a unique 16byte id we can fit into a rtp header extension.

Also updates the media info key to have a UID part so we can continue wildcard matching redis keys.