### PR TITLE
Use send only for sub connections

### DIFF
--- a/pkg/node/sfu/internal.go
+++ b/pkg/node/sfu/internal.go
@@ -230,7 +230,7 @@ func subscribe(msg map[string]interface{}) (map[string]interface{}, *nprotoo.Err
 		streamID := strings.Split(msid, " ")[0]
 		trackID := track.ID
 		log.Infof("AddTrack: codec:%s, ssrc:%d, pt:%d, streamID %s, trackID %s", track.Codec, ssrc, pt, streamID, trackID)
-		_, err := sub.AddTrack(ssrc, pt, streamID, track.ID)
+		_, err := sub.AddSendTrack(ssrc, pt, streamID, track.ID)
 		if err != nil {
 			log.Errorf("err=%v", err)
 		}

--- a/pkg/rtc/rtc_test.go
+++ b/pkg/rtc/rtc_test.go
@@ -99,7 +99,7 @@ func TestWebRTCTransportP2P(t *testing.T) {
 	}
 
 	// pub add track
-	_, err := pub.AddTrack(476325762, webrtc.DefaultPayloadTypeVP8, "video", "pion")
+	_, err := pub.AddSendTrack(476325762, webrtc.DefaultPayloadTypeVP8, "video", "pion")
 	if err != nil {
 		t.Fatalf("pub.AddTrack err=%v", err)
 	}

--- a/pkg/rtc/transport/webrtctransport.go
+++ b/pkg/rtc/transport/webrtctransport.go
@@ -226,7 +226,7 @@ func (w *WebRTCTransport) SetRemoteSDP(sdp webrtc.SessionDescription) error {
 }
 
 // AddTrack add track to pc
-func (w *WebRTCTransport) AddTrack(ssrc uint32, pt uint8, streamID string, trackID string) (*webrtc.Track, error) {
+func (w *WebRTCTransport) AddSendTrack(ssrc uint32, pt uint8, streamID string, trackID string) (*webrtc.Track, error) {
 	if w.pc == nil {
 		return nil, errInvalidPC
 	}
@@ -234,7 +234,9 @@ func (w *WebRTCTransport) AddTrack(ssrc uint32, pt uint8, streamID string, track
 	if err != nil {
 		return nil, err
 	}
-	if _, err = w.pc.AddTrack(track); err != nil {
+
+	_, err = w.pc.AddTransceiverFromTrack(track, webrtc.RtpTransceiverInit{Direction: webrtc.RTPTransceiverDirectionSendonly})
+	if err != nil {
 		return nil, err
 	}
 

--- a/pkg/rtc/transport/webrtctransport_test.go
+++ b/pkg/rtc/transport/webrtctransport_test.go
@@ -27,7 +27,7 @@ func TestWebRTCTransportAnswer(t *testing.T) {
 		t.Fatalf("err=%v", err)
 	}
 
-	_, err = pub.AddTrack(12345, webrtc.DefaultPayloadTypeH264, "video", "pion")
+	_, err = pub.AddSendTrack(12345, webrtc.DefaultPayloadTypeH264, "video", "pion")
 	if err != nil {
 		t.Fatalf("err=%v", err)
 	}


### PR DESCRIPTION
Make sure subscribe SDP answer is sendonly.

This is part of the fixes for firefox, but is something we should be doing anyway.