### PR TITLE
The uid in the pub information should be the id of the push stream user

### DIFF
--- a/pkg/node/islb/internal.go
+++ b/pkg/node/islb/internal.go
@@ -263,7 +263,7 @@ func getPubs(data map[string]interface{}) (map[string]interface{}, *nprotoo.Erro
 				tracks[msid] = *infos
 			}
 		}
-		pub := util.Map("rid", rid, "uid", uid, "mid", info.MID, "info", fields["info"], "tracks", tracks)
+		pub := util.Map("rid", rid, "uid", info.UID, "mid", info.MID, "info", fields["info"], "tracks", tracks)
 		pubs = append(pubs, pub)
 	}
 


### PR DESCRIPTION
When a user joins, the uid in the published information obtained should be the uid of the current stream pusher, so that the client can distinguish the target user of the subscription based on the uid of the stream-add event.