### PR TITLE
Remove node logic from test report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ _test_job: &test_job
   before_script:
     - docker-compose -f docker-compose.test.yml up -d
   script:
-    - testpkgs=${TEST_PACKAGES:-$(go list ./... | grep -v cmd | grep -v conf)}
+    - testpkgs=${TEST_PACKAGES:-$(go list ./... | grep -v cmd | grep -v conf | grep -v node)}
     - coverpkgs=$(echo "${testpkgs}" | paste -s -d ',')
     - |
       go test \


### PR DESCRIPTION
Removing the node folder from test coverage since it is tough to test. Maybe we start simple and start with improving test coverage for library modules