### PR TITLE
Write avp output to host with docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
     image: pionwebrtc/ion-avp:0.2.0
     volumes:
       - "./docker/avp.toml:/configs/avp.toml"
+      - "./:/out/"
     depends_on:
       - nats
       - etcd

--- a/docker/avp.toml
+++ b/docker/avp.toml
@@ -18,7 +18,7 @@ videomaxlate = 200
 [plugins.webmsaver]
 on = true
 # webm output path
-path = "./"
+path = "./out/"
 
 [rtp]
 # listen port


### PR DESCRIPTION
This may need a corresponding mkdir on avp when not running in docker compose.