### PR TITLE
Add release script + travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ _build_avp_docker_job: &build_avp_docker_job
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   deploy:
     provider: script
-    script: docker push pionwebrtc/ion-avp:latest
+    script: if [ -n "$TRAVIS_TAG" ]; then docker push pionwebrtc/ion-avp:"$TRAVIS_TAG"; else docker push pionwebrtc/ion-avp:latest; fi
     on:
       branch: master
 
@@ -58,10 +58,9 @@ _build_biz_docker_job: &build_biz_docker_job
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   deploy:
     provider: script
-    script: docker push pionwebrtc/ion-biz:latest
+    script: if [ -n "$TRAVIS_TAG" ]; then docker push pionwebrtc/ion-biz:"$TRAVIS_TAG"; else docker push pionwebrtc/ion-biz:latest; fi
     on:
       branch: master
-      # tags: true
 
 _build_islb_docker_job: &build_islb_docker_job
   env: CACHE_NAME=build_islb_docker
@@ -71,10 +70,9 @@ _build_islb_docker_job: &build_islb_docker_job
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   deploy:
     provider: script
-    script: docker push pionwebrtc/ion-islb:latest
+    script: if [ -n "$TRAVIS_TAG" ]; then docker push pionwebrtc/ion-islb:"$TRAVIS_TAG"; else docker push pionwebrtc/ion-islb:latest; fi
     on:
       branch: master
-      # tags: true
 
 _build_sfu_docker_job: &build_sfu_docker_job
   env: CACHE_NAME=build_sfu_docker
@@ -84,10 +82,9 @@ _build_sfu_docker_job: &build_sfu_docker_job
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   deploy:
     provider: script
-    script: docker push pionwebrtc/ion-sfu:latest
+    script: if [ -n "$TRAVIS_TAG" ]; then docker push pionwebrtc/ion-sfu:"$TRAVIS_TAG"; else docker push pionwebrtc/ion-sfu:latest; fi
     on:
       branch: master
-      # tags: true
 
 _test_job: &test_job
   env: CACHE_NAME=test

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)'
+
+step="$1"
+if [ -z "$1" ]
+then
+  step=patch
+fi
+
+base="$2"
+if [ -z "$2" ]
+then
+  base=$(git tag 2>/dev/null| tail -n 1)
+  if [ -z "$base" ]
+  then
+    base=0.0.0
+  fi
+fi
+
+MAJOR=`echo $base | sed -e "s#$RE#\1#"`
+MINOR=`echo $base | sed -e "s#$RE#\2#"`
+PATCH=`echo $base | sed -e "s#$RE#\3#"`
+
+case "$step" in
+  major)
+    let MAJOR+=1
+    ;;
+  minor)
+    let MINOR+=1
+    ;;
+  patch)
+    let PATCH+=1
+    ;;
+esac
+
+next="v$MAJOR.$MINOR.$PATCH"
+echo "$base -> $next"
+ 
+git commit --allow-empty -am "$next"
+git tag $next
+git push --atomic origin tag $next
+


### PR DESCRIPTION
Adds a release script that allows us to do `./scripts/release.sh major|minor|patch` to cut a new release. It should trigger travis to build and tag new docker images. Then I think renovate bot should open a PR to bump the versions in docker-compose.