### PR TITLE
Basic remb feedback from subs to pub

### DIFF
--- a/cmd/sfu/main.go
+++ b/cmd/sfu/main.go
@@ -61,6 +61,7 @@ func init() {
 		panic(err)
 	}
 	rtc.InitPlugins(pluginConfig)
+	rtc.InitRouter(*conf.Router)
 }
 
 func main() {

--- a/configs/docker/sfu.toml
+++ b/configs/docker/sfu.toml
@@ -7,6 +7,13 @@ dc = "dc1"
 # internet ip
 addr = "127.0.0.1"
 
+[router]
+# pass bandwidth feeback to pub
+rembfeedback = false
+# Cap bandwidth feedback
+minbandwidth = 100000
+maxbandwidth = 5000000
+
 [plugins]
 on = true
 

--- a/configs/sfu.toml
+++ b/configs/sfu.toml
@@ -5,6 +5,13 @@ dc = "dc1"
 # internet ip
 addr = "127.0.0.1"
 
+[router]
+# pass bandwidth feeback to pub
+rembfeedback = false
+# Cap bandwidth feedback
+minbandwidth = 100000
+maxbandwidth = 5000000
+
 [plugins]
 on = true
 

--- a/pkg/conf/sfu/conf.go
+++ b/pkg/conf/sfu/conf.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pion/ion/pkg/rtc"
 	"github.com/spf13/viper"
 )
 
@@ -21,6 +22,7 @@ var (
 	Log     = &cfg.Log
 	Etcd    = &cfg.Etcd
 	Nats    = &cfg.Nats
+	Router  = &cfg.Router
 )
 
 func init() {
@@ -89,13 +91,14 @@ type rtp struct {
 }
 
 type config struct {
-	Global  global  `mapstructure:"global"`
-	Plugins plugins `mapstructure:"plugins"`
-	WebRTC  webrtc  `mapstructure:"webrtc"`
-	Rtp     rtp     `mapstructure:"rtp"`
-	Log     log     `mapstructure:"log"`
-	Etcd    etcd    `mapstructure:"etcd"`
-	Nats    nats    `mapstructure:"nats"`
+	Global  global           `mapstructure:"global"`
+	Router  rtc.RouterConfig `mapstructure:"router"`
+	Plugins plugins          `mapstructure:"plugins"`
+	WebRTC  webrtc           `mapstructure:"webrtc"`
+	Rtp     rtp              `mapstructure:"rtp"`
+	Log     log              `mapstructure:"log"`
+	Etcd    etcd             `mapstructure:"etcd"`
+	Nats    nats             `mapstructure:"nats"`
 	CfgFile string
 }
 

--- a/pkg/rtc/router.go
+++ b/pkg/rtc/router.go
@@ -33,6 +33,7 @@ type Router struct {
 	pluginChain   *plugins.PluginChain
 	subChans      map[proto.MID]chan *rtp.Packet
 	subShutdownCh chan string
+	rembChan      chan *rtcp.ReceiverEstimatedMaximumBitrate
 }
 
 // NewRouter return a new Router
@@ -44,6 +45,7 @@ func NewRouter(id proto.MID) *Router {
 		pluginChain:   plugins.NewPluginChain(string(id)),
 		subChans:      make(map[proto.MID]chan *rtp.Packet),
 		subShutdownCh: make(chan string, 1),
+		rembChan:      make(chan *rtcp.ReceiverEstimatedMaximumBitrate),
 	}
 }
 
@@ -56,6 +58,7 @@ func (r *Router) InitPlugins(config plugins.Config) error {
 }
 
 func (r *Router) start() {
+	go r.rembLoop()
 	go func() {
 		defer util.Recover("[Router.start]")
 		for {
@@ -154,6 +157,56 @@ func (r *Router) subWriteLoop(subID proto.MID, trans transport.Transport) {
 	log.Infof("Closing sub writer")
 }
 
+func (r *Router) rembLoop() {
+	lastRembTime := time.Now()
+	maxRembTime := 200 * time.Millisecond
+	var rembMin uint64 = 100000
+	var lowest uint64 = 99999999999999999
+	var rembCount, rembTotalRate uint64
+
+	for pkt := range r.rembChan {
+		// Update stats
+		rembCount++
+		rembTotalRate += pkt.Bitrate
+		if pkt.Bitrate < lowest {
+			lowest = pkt.Bitrate
+		}
+
+		// Send upstream if time
+		if time.Since(lastRembTime) > maxRembTime {
+			lastRembTime = time.Now()
+			avg := uint64(rembTotalRate / rembCount)
+
+			_ = avg
+			target := lowest // or lowest
+
+			if target < rembMin {
+				target = rembMin
+			}
+
+			newPkt := &rtcp.ReceiverEstimatedMaximumBitrate{
+				Bitrate:    target,
+				SenderSSRC: 1,
+				SSRCs:      pkt.SSRCs,
+			}
+
+			log.Infof("Router.rembLoop send REMB: %+v", newPkt)
+
+			if r.GetPub() != nil {
+				err := r.GetPub().WriteRTCP(newPkt)
+				if err != nil {
+					log.Errorf("Router.AddSub REMB err => %+v", err)
+				}
+			}
+
+			// Reset stats
+			rembCount = 0
+			rembTotalRate = 0
+			lowest = 99999999999999999
+		}
+	}
+}
+
 func (r *Router) subFeedbackLoop(subID proto.MID, trans transport.Transport) {
 	for pkt := range trans.GetRTCPChan() {
 		if r.stop {
@@ -169,6 +222,8 @@ func (r *Router) subFeedbackLoop(subID proto.MID, trans transport.Transport) {
 					log.Errorf("Router pli err => %+v", err)
 				}
 			}
+		case *rtcp.ReceiverEstimatedMaximumBitrate:
+			r.rembChan <- pkt
 		case *rtcp.TransportLayerNack:
 			// log.Infof("Router got nack: %+v", pkt)
 			nack := pkt

--- a/pkg/rtc/router.go
+++ b/pkg/rtc/router.go
@@ -20,6 +20,7 @@ const (
 
 type RouterConfig struct {
 	MinBandwidth uint64 `mapstructure:"minbandwidth"`
+	REMBFeedback bool   `mapstructure:"rembfeedback"`
 }
 
 //                                      +--->sub
@@ -62,7 +63,9 @@ func (r *Router) InitPlugins(config plugins.Config) error {
 }
 
 func (r *Router) start() {
-	go r.rembLoop()
+	if routerConfig.REMBFeedback {
+		go r.rembLoop()
+	}
 	go func() {
 		defer util.Recover("[Router.start]")
 		for {
@@ -230,7 +233,9 @@ func (r *Router) subFeedbackLoop(subID proto.MID, trans transport.Transport) {
 				}
 			}
 		case *rtcp.ReceiverEstimatedMaximumBitrate:
-			r.rembChan <- pkt
+			if routerConfig.REMBFeedback {
+				r.rembChan <- pkt
+			}
 		case *rtcp.TransportLayerNack:
 			// log.Infof("Router got nack: %+v", pkt)
 			nack := pkt

--- a/pkg/rtc/router.go
+++ b/pkg/rtc/router.go
@@ -18,6 +18,10 @@ const (
 	liveCycle   = 6 * time.Second
 )
 
+type RouterConfig struct {
+	MinBandwidth uint64 `mapstructure:"minbandwidth"`
+}
+
 //                                      +--->sub
 //                                      |
 // pub--->pubCh-->pluginChain-->subCh---+--->sub
@@ -160,7 +164,10 @@ func (r *Router) subWriteLoop(subID proto.MID, trans transport.Transport) {
 func (r *Router) rembLoop() {
 	lastRembTime := time.Now()
 	maxRembTime := 200 * time.Millisecond
-	var rembMin uint64 = 100000
+	rembMin := routerConfig.MinBandwidth
+	if rembMin == 0 {
+		rembMin = 10000
+	}
 	var lowest uint64 = 99999999999999999
 	var rembCount, rembTotalRate uint64
 

--- a/pkg/rtc/rtc.go
+++ b/pkg/rtc/rtc.go
@@ -25,9 +25,8 @@ var (
 	//CleanChannel return the dead pub's mid
 	CleanChannel  = make(chan proto.MID, maxCleanSize)
 	pluginsConfig plugins.Config
-	routerConfig RouterConfig
-
-	stop bool
+	routerConfig  RouterConfig
+	stop          bool
 )
 
 // InitIce ice urls

--- a/pkg/rtc/rtc.go
+++ b/pkg/rtc/rtc.go
@@ -25,6 +25,7 @@ var (
 	//CleanChannel return the dead pub's mid
 	CleanChannel  = make(chan proto.MID, maxCleanSize)
 	pluginsConfig plugins.Config
+	routerConfig RouterConfig
 
 	stop bool
 )
@@ -33,6 +34,10 @@ var (
 func InitIce(iceServers []webrtc.ICEServer, icePortStart, icePortEnd uint16) error {
 	//init ice urls and ICE settings
 	return transport.InitWebRTC(iceServers, icePortStart, icePortEnd)
+}
+
+func InitRouter(config RouterConfig) {
+	routerConfig = config
 }
 
 // InitPlugins plugins config


### PR DESCRIPTION
Aggregate sub remb messages and feed back single report to pub. This allows for video quality adaption when there are subs with bad/slow connection.

Requires extmap and abs-send-time support for the client remb calc to work properly, so this feature is disabled by default.

TODO
- [x] Config minimum rate