### PR TITLE
Support h264 between chrome and firefox

### DIFF
--- a/pkg/node/sfu/util.go
+++ b/pkg/node/sfu/util.go
@@ -52,6 +52,10 @@ func getPubPTForTrack(videoCodec string, track *sdp.TrackInfo, sdpObj *sdp.SDPIn
 			}
 		} else if track.GetMedia() == "video" {
 			codecName = strings.ToUpper(codec.GetCodec())
+			//skip 126 for pub, chrome sub will decode fail when H264 playload type is 126
+			if codecName == "H264" && payload == 126 {
+				continue
+			}
 			if codecName == videoCodec {
 				pt = uint8(payload)
 				break

--- a/pkg/rtc/router.go
+++ b/pkg/rtc/router.go
@@ -162,14 +162,14 @@ func (r *Router) subFeedbackLoop(subID string, trans transport.Transport) {
 		case *rtcp.PictureLossIndication, *rtcp.FullIntraRequest:
 			if r.GetPub() != nil {
 				// Request a Key Frame
-				log.Infof("Router.AddSub got pli: %+v", pkt)
+				log.Infof("Router got pli: %d", pkt.DestinationSSRC())
 				err := r.GetPub().WriteRTCP(pkt)
 				if err != nil {
-					log.Errorf("Router.AddSub pli err => %+v", err)
+					log.Errorf("Router pli err => %+v", err)
 				}
 			}
 		case *rtcp.TransportLayerNack:
-			// log.Infof("Router.AddSub got nack: %+v", pkt)
+			// log.Infof("Router got nack: %+v", pkt)
 			nack := pkt
 			for _, nackPair := range nack.Nacks {
 				if !r.ReSendRTP(subID, nack.MediaSSRC, nackPair.PacketID) {
@@ -182,7 +182,7 @@ func (r *Router) subFeedbackLoop(subID string, trans transport.Transport) {
 					if r.pub != nil {
 						err := r.GetPub().WriteRTCP(n)
 						if err != nil {
-							log.Errorf("Router.AddSub nack WriteRTCP err => %+v", err)
+							log.Errorf("Router nack WriteRTCP err => %+v", err)
 						}
 					}
 				}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -14,7 +14,6 @@ import (
 	nprotoo "github.com/cloudwebrtc/nats-protoo"
 	"github.com/pion/ion/pkg/log"
 	"github.com/pion/stun"
-	"github.com/pion/webrtc/v2"
 )
 
 var (
@@ -194,15 +193,6 @@ func GetLostSN(begin, bitmap uint16) []uint16 {
 
 func GetMills() int64 {
 	return time.Now().UnixNano() / 1e6
-}
-
-func IsVideo(pt uint8) bool {
-	if pt == webrtc.DefaultPayloadTypeVP8 ||
-		pt == webrtc.DefaultPayloadTypeVP9 ||
-		pt == webrtc.DefaultPayloadTypeH264 {
-		return true
-	}
-	return false
 }
 
 func StrToUint8(str string) uint8 {


### PR DESCRIPTION
Use payload type 97 and fmtp="a=fmtp:97 profile-level-id=42e01f;level-asymmetry-allowed=1"

#### Description
Now chrome and firefox works well when video codec is vp8|vp9|h264

#### Reference issue
Fixes #245 
