### PR TITLE
Copy default configs into docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,6 @@ islb.Dockerfile
 web.Dockerfile
 docker-compose.yml
 docker
-configs
 docs
 screenshots
 */*/node_modules

--- a/docker-compose.stable.yml
+++ b/docker-compose.stable.yml
@@ -3,9 +3,6 @@ version: "3.7"
 services:
   sfu:
     image: pionwebrtc/ion-sfu:v0.4.1
-    command: "-c /configs/sfu.toml"
-    volumes:
-      - "./configs/docker/sfu.toml:/configs/sfu.toml"
     ports:
       - "5000-5200:5000-5200/udp"
     depends_on:
@@ -16,9 +13,6 @@ services:
 
   biz:
     image: pionwebrtc/ion-biz:v0.4.1
-    command: "-c /configs/biz.toml"
-    volumes:
-      - "./configs/docker/biz.toml:/configs/biz.toml"
     ports:
       - 8443:8443
     networks:
@@ -29,9 +23,6 @@ services:
 
   islb:
     image: pionwebrtc/ion-islb:v0.4.1
-    command: "-c /configs/islb.toml"
-    volumes:
-      - "./configs/docker/islb.toml:/configs/islb.toml"
     depends_on:
       - nats
       - etcd

--- a/docker/avp.Dockerfile
+++ b/docker/avp.Dockerfile
@@ -18,5 +18,7 @@ FROM alpine:3.11.6
 RUN apk --no-cache add ca-certificates
 COPY --from=0 /avp /usr/local/bin/avp
 
+COPY configs/docker/avp.toml /configs/avp.toml
+
 ENTRYPOINT ["/usr/local/bin/avp"]
 CMD ["-c", "/configs/avp.toml"]

--- a/docker/biz.Dockerfile
+++ b/docker/biz.Dockerfile
@@ -18,5 +18,7 @@ FROM alpine:3.11.6
 RUN apk --no-cache add ca-certificates
 COPY --from=0 /biz /usr/local/bin/biz
 
+COPY configs/docker/biz.toml /configs/biz.toml
+
 ENTRYPOINT ["/usr/local/bin/biz"]
 CMD ["-c", "/configs/biz.toml"]

--- a/docker/islb.Dockerfile
+++ b/docker/islb.Dockerfile
@@ -17,5 +17,7 @@ FROM alpine:3.11.6
 RUN apk --no-cache add ca-certificates
 COPY --from=0 /islb /usr/local/bin/islb
 
+COPY configs/docker/islb.toml /configs/islb.toml
+
 ENTRYPOINT ["/usr/local/bin/islb"]
 CMD ["-c", "/configs/islb.toml"]

--- a/docker/sfu.Dockerfile
+++ b/docker/sfu.Dockerfile
@@ -18,5 +18,7 @@ FROM alpine:3.11.6
 RUN apk --no-cache add ca-certificates
 COPY --from=0 /sfu /usr/local/bin/sfu
 
+COPY configs/docker/sfu.toml /configs/sfu.toml
+
 ENTRYPOINT ["/usr/local/bin/sfu"]
 CMD ["-c", "/configs/sfu.toml"]


### PR DESCRIPTION
This copies configs into the docker images and modifies the `docker-compose.stable.yml` config to use them. This will help avoid issues like #268.

If we are ok with this, I will update the readme to describe how to overload.