### PR TITLE
Remove login/close

### DIFF
--- a/pkg/node/biz/client.go
+++ b/pkg/node/biz/client.go
@@ -15,12 +15,6 @@ var (
 	midError = util.NewNpError(codeMIDErr, codeStr(codeMIDErr))
 )
 
-func login(peer *signal.Peer, msg proto.LoginMsg) (interface{}, *nprotoo.Error) {
-	log.Infof("biz.login peer.ID()=%s msg=%v", peer.ID(), msg)
-	//TODO auth check, maybe jwt
-	return emptyMap, nil
-}
-
 // join room
 func join(peer *signal.Peer, msg proto.JoinMsg) (interface{}, *nprotoo.Error) {
 	log.Infof("biz.join peer.ID()=%s msg=%v", peer.ID(), msg)
@@ -88,18 +82,13 @@ func leave(peer *signal.Peer, msg proto.LeaveMsg) (interface{}, *nprotoo.Error) 
 		return nil, util.NewNpError(500, "Not found any node for islb.")
 	}
 
-	islb.AsyncRequest(proto.IslbOnStreamRemove, util.Map("rid", rid, "uid", uid, "mid", ""))
+	islb.AsyncRequest(proto.IslbOnStreamRemove, util.Map("rid", rid, "uid", uid))
 	_, err := islb.SyncRequest(proto.IslbClientOnLeave, util.Map("rid", rid, "uid", uid))
 	if err != nil {
 		log.Errorf("IslbOnStreamRemove failed %v", err.Error())
 	}
 	signal.DelPeer(rid, peer.ID())
 	return emptyMap, nil
-}
-
-func clientClose(peer *signal.Peer, msg proto.CloseMsg) (interface{}, *nprotoo.Error) {
-	log.Infof("biz.close peer.ID()=%s msg=%v", peer.ID(), msg)
-	return leave(peer, msg.LeaveMsg)
 }
 
 func publish(peer *signal.Peer, msg proto.PublishMsg) (interface{}, *nprotoo.Error) {

--- a/pkg/node/biz/dispatch.go
+++ b/pkg/node/biz/dispatch.go
@@ -29,16 +29,6 @@ func Entry(method string, peer *signal.Peer, msg json.RawMessage, accept signal.
 
 	//TODO DRY this up
 	switch method {
-	case proto.ClientClose:
-		var msgData proto.CloseMsg
-		if topErr = ParseProtoo(msg, &msgData); topErr == nil {
-			result, topErr = clientClose(peer, msgData)
-		}
-	case proto.ClientLogin:
-		var msgData proto.LoginMsg
-		if topErr = ParseProtoo(msg, &msgData); topErr == nil {
-			result, topErr = login(peer, msgData)
-		}
 	case proto.ClientJoin:
 		var msgData proto.JoinMsg
 		if topErr = ParseProtoo(msg, &msgData); topErr == nil {

--- a/pkg/node/islb/internal.go
+++ b/pkg/node/islb/internal.go
@@ -380,7 +380,7 @@ func handleRequest(rpcID string) {
 		go func(request nprotoo.Request, accept nprotoo.RespondFunc, reject nprotoo.RejectFunc) {
 			method := request.Method
 			msg := request.Data
-			log.Infof("method => %s, data => %v", method, msg)
+			log.Infof("method => %s", method)
 
 			var result interface{}
 			err := util.NewNpError(400, fmt.Sprintf("Unkown method [%s]", method))

--- a/pkg/proto/biz.go
+++ b/pkg/proto/biz.go
@@ -51,16 +51,9 @@ type JoinMsg struct {
 	Info ClientUserInfo `json:"info"`
 }
 
-type LoginMsg struct {
-}
-
 type LeaveMsg struct {
 	RoomInfo
 	Info ClientUserInfo `json:"info"`
-}
-
-type CloseMsg struct {
-	LeaveMsg
 }
 
 type PublishMsg struct {

--- a/pkg/proto/proto.go
+++ b/pkg/proto/proto.go
@@ -8,14 +8,12 @@ import (
 
 const (
 	// client to ion
-	ClientLogin       = "login"
 	ClientJoin        = "join"
 	ClientLeave       = "leave"
 	ClientPublish     = "publish"
 	ClientUnPublish   = "unpublish"
 	ClientSubscribe   = "subscribe"
 	ClientUnSubscribe = "unsubscribe"
-	ClientClose       = "close"
 	ClientBroadcast   = "broadcast"
 	ClientTrickleICE  = "trickle"
 

--- a/pkg/signal/handle.go
+++ b/pkg/signal/handle.go
@@ -64,10 +64,6 @@ func in(transport *transport.WebSocketTransport, request *http.Request) {
 		bizCall(method, peer, data, emptyAccept, reject)
 	}
 
-	type CloseMsg struct {
-		Rid proto.RID `json:"rid"`
-	}
-
 	handleClose := func(code int, err string) {
 		roomLock.RLock()
 		defer roomLock.RUnlock()
@@ -76,9 +72,11 @@ func in(transport *transport.WebSocketTransport, request *http.Request) {
 		for _, room := range rooms {
 			if room != nil {
 				if code > 1000 {
-					msg := CloseMsg{Rid: room.ID()}
+					msg := proto.LeaveMsg{
+						RoomInfo: proto.RoomInfo{RID: room.ID()},
+					}
 					msgStr, _ := json.Marshal(msg)
-					bizCall(proto.ClientClose, peer, msgStr, emptyAccept, reject)
+					bizCall(proto.ClientLeave, peer, msgStr, emptyAccept, reject)
 				}
 				room.RemovePeer(peer.ID())
 			}


### PR DESCRIPTION
Removes the login method since JWT issuance should be handled by an auth service. Removes redundant `ClientClose` and uses `ClientLeave` instead.