### PR TITLE
Support jwt auth

### DIFF
--- a/cmd/biz/main.go
+++ b/cmd/biz/main.go
@@ -48,7 +48,7 @@ func main() {
 	biz.Init(conf.Global.Dc, serviceNode.NodeInfo().ID, rpcID, eventID, conf.Nats.URL)
 
 	serviceWatcher := discovery.NewServiceWatcher(conf.Etcd.Addrs, conf.Global.Dc)
-	serviceWatcher.WatchServiceNode("islb", biz.WatchServiceNodes)
+	go serviceWatcher.WatchServiceNode("islb", biz.WatchServiceNodes)
 
 	defer close()
 	select {}

--- a/cmd/biz/main.go
+++ b/cmd/biz/main.go
@@ -18,7 +18,7 @@ func init() {
 		Port:          conf.Signal.Port,
 		CertFile:      conf.Signal.Cert,
 		KeyFile:       conf.Signal.Key,
-		Authenticate:  conf.Signal.Authenticate,
+		Authorization: conf.Signal.Authorization,
 		WebSocketPath: conf.Signal.WebSocketPath,
 	}, conf.Signal.AllowDisconnected, biz.Entry)
 }

--- a/cmd/biz/main.go
+++ b/cmd/biz/main.go
@@ -13,7 +13,14 @@ import (
 
 func init() {
 	log.Init(conf.Log.Level)
-	signal.Init(conf.Signal.Host, conf.Signal.Port, conf.Signal.Cert, conf.Signal.Key, conf.Signal.AllowDisconnected, biz.Entry)
+	signal.Init(signal.WebSocketServerConfig{
+		Host:          conf.Signal.Host,
+		Port:          conf.Signal.Port,
+		CertFile:      conf.Signal.Cert,
+		KeyFile:       conf.Signal.Key,
+		Authenticate:  conf.Signal.Authenticate,
+		WebSocketPath: conf.Signal.WebSocketPath,
+	}, conf.Signal.AllowDisconnected, biz.Entry)
 }
 
 func close() {

--- a/cmd/biz/main.go
+++ b/cmd/biz/main.go
@@ -14,12 +14,12 @@ import (
 func init() {
 	log.Init(conf.Log.Level)
 	signal.Init(signal.WebSocketServerConfig{
-		Host:          conf.Signal.Host,
-		Port:          conf.Signal.Port,
-		CertFile:      conf.Signal.Cert,
-		KeyFile:       conf.Signal.Key,
-		Authorization: conf.Signal.Authorization,
-		WebSocketPath: conf.Signal.WebSocketPath,
+		Host:           conf.Signal.Host,
+		Port:           conf.Signal.Port,
+		CertFile:       conf.Signal.Cert,
+		KeyFile:        conf.Signal.Key,
+		WebSocketPath:  conf.Signal.WebSocketPath,
+		AuthConnection: conf.Signal.AuthConnection,
 	}, conf.Signal.AllowDisconnected, biz.Entry)
 }
 
@@ -45,7 +45,7 @@ func main() {
 
 	rpcID := serviceNode.GetRPCChannel()
 	eventID := serviceNode.GetEventChannel()
-	biz.Init(conf.Global.Dc, serviceNode.NodeInfo().ID, rpcID, eventID, conf.Nats.URL)
+	biz.Init(conf.Global.Dc, serviceNode.NodeInfo().ID, rpcID, eventID, conf.Nats.URL, conf.Signal.AuthRoom)
 
 	serviceWatcher := discovery.NewServiceWatcher(conf.Etcd.Addrs, conf.Global.Dc)
 	go serviceWatcher.WatchServiceNode("islb", biz.WatchServiceNodes)

--- a/configs/biz.toml
+++ b/configs/biz.toml
@@ -21,8 +21,9 @@ host = "0.0.0.0"
 port = "8443"
 # cert= "configs/certs/cert.pem"
 # key= "configs/certs/key.pem"
+path = "/ws"
+authenticate = false
 allow_disconnected = false
 
 [nats]
 url = "nats://127.0.0.1:4223"
-

--- a/configs/biz.toml
+++ b/configs/biz.toml
@@ -22,7 +22,7 @@ port = "8443"
 # cert= "configs/certs/cert.pem"
 # key= "configs/certs/key.pem"
 path = "/ws"
-authenticate = false
+authorization = false
 allow_disconnected = false
 
 [nats]

--- a/configs/biz.toml
+++ b/configs/biz.toml
@@ -8,8 +8,8 @@ addr = "127.0.0.1"
 dc = "dc1"
 
 [log]
-level = "info"
-# level = "debug"
+#level = "info"
+level = "debug"
 
 [etcd]
 # ["ip:port", "ip:port"]
@@ -25,7 +25,7 @@ path = "/ws"
 allow_disconnected = false
 
 [signal.auth_connection]
-enabled = true
+enabled = false 
 key_type = "HMAC"  # this selects the Signing method https://godoc.org/github.com/dgrijalva/jwt-go#SigningMethod
 key = ""
 
@@ -33,7 +33,7 @@ key = ""
 [signal.auth_room]
 enabled = true
 key_type = "HMAC"
-key = ""
+key = "055sQnOJIUn39fa40tKfdrLKF8aQ+NGcUyR24INae6A5HaomQ18fLRsGtnzYJ2uS"
 
 [nats]
 url = "nats://127.0.0.1:4223"

--- a/configs/biz.toml
+++ b/configs/biz.toml
@@ -22,8 +22,18 @@ port = "8443"
 # cert= "configs/certs/cert.pem"
 # key= "configs/certs/key.pem"
 path = "/ws"
-authorization = false
 allow_disconnected = false
+
+[signal.auth_connection]
+enabled = true
+key_type = "HMAC"  # this selects the Signing method https://godoc.org/github.com/dgrijalva/jwt-go#SigningMethod
+key = ""
+
+
+[signal.auth_room]
+enabled = true
+key_type = "HMAC"
+key = ""
 
 [nats]
 url = "nats://127.0.0.1:4223"

--- a/configs/biz.toml
+++ b/configs/biz.toml
@@ -25,15 +25,14 @@ path = "/ws"
 allow_disconnected = false
 
 [signal.auth_connection]
-enabled = false 
+enabled = true 
 key_type = "HMAC"  # this selects the Signing method https://godoc.org/github.com/dgrijalva/jwt-go#SigningMethod
-key = ""
-
+key = "1q2dGu5pzikcrECJgW3ADfXX3EsmoD99SYvSVCpDsJrAqxou5tUNbHPvkEFI4bTS"
 
 [signal.auth_room]
 enabled = true
 key_type = "HMAC"
-key = "055sQnOJIUn39fa40tKfdrLKF8aQ+NGcUyR24INae6A5HaomQ18fLRsGtnzYJ2uS"
+key = "1q2dGu5pzikcrECJgW3ADfXX3EsmoD99SYvSVCpDsJrAqxou5tUNbHPvkEFI4bTS"
 
 [nats]
 url = "nats://127.0.0.1:4223"

--- a/configs/docker/biz.toml
+++ b/configs/docker/biz.toml
@@ -8,8 +8,8 @@ addr = "127.0.0.1"
 dc = "dc1"
 
 [log]
-level = "info"
-# level = "debug"
+# level = "info"
+level = "debug"
 
 [etcd]
 # ["ip:port", "ip:port"]
@@ -21,6 +21,9 @@ host = "0.0.0.0"
 port = "8443"
 # cert= "/configs/certs/cert.pem"
 # key= "/configs/certs/key.pem"
+path = "/ws"
+authenticate = false
+allow_disconnected = false
 
 [nats]
 url = "nats://nats:4222"

--- a/configs/docker/biz.toml
+++ b/configs/docker/biz.toml
@@ -22,7 +22,7 @@ port = "8443"
 # cert= "/configs/certs/cert.pem"
 # key= "/configs/certs/key.pem"
 path = "/ws"
-authenticate = false
+authorization = false
 allow_disconnected = false
 
 [nats]

--- a/configs/docker/biz.toml
+++ b/configs/docker/biz.toml
@@ -22,8 +22,18 @@ port = "8443"
 # cert= "/configs/certs/cert.pem"
 # key= "/configs/certs/key.pem"
 path = "/ws"
-authorization = false
 allow_disconnected = false
+
+[signal.auth_connection]
+enabled = true 
+key_type = "HMAC"  # this selects the Signing method https://godoc.org/github.com/dgrijalva/jwt-go#SigningMethod
+key = "1q2dGu5pzikcrECJgW3ADfXX3EsmoD99SYvSVCpDsJrAqxou5tUNbHPvkEFI4bTS"
+
+[signal.auth_room]
+enabled = true
+key_type = "HMAC"
+key = "1q2dGu5pzikcrECJgW3ADfXX3EsmoD99SYvSVCpDsJrAqxou5tUNbHPvkEFI4bTS"
+
 
 [nats]
 url = "nats://nats:4222"

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,20 @@
+# Authentication
+
+Ion supports JWT based authorization. Token issuance and verification is not handled by Ion.
+
+To enable authorization, set the `authorization` value in the `biz` config.
+
+```toml
+[signal]
+authorization = true
+```
+
+JWT tokens should be passed using an `access_token` query parameter in the websocket connection url to `biz`. Each token should contain a claim with room permissions:
+
+```json
+{
+  "id": "...", // room id
+  "videopublish": true, // can a peer publish video
+  "audiopublish": true // can a peer publish audio
+}
+```

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,19 +1,34 @@
 # Authentication
 
-Ion supports JWT based authorization. Token issuance and verification is not handled by Ion.
+Ion supports JWT based authorization. Token issuance is not handled by ION, but the token signature is validated using the key set in the config.  Both connection and message level authentication is supported (for rooms).
 
-To enable authorization, set the `authorization` value in the `biz` config.
+To enable authentication, set enabled to true in the config for the type you want
 
 ```toml
-[signal]
-authorization = true
+[signal.auth_connection]
+enabled = true 
+key_type = "HMAC"  
+key = "$HMAC_SECRET"
+
+[signal.auth_room]
+enabled = true
+key_type = "HMAC"
+key = "$HMAC_SECRET"
 ```
 
-JWT tokens should be passed using an `access_token` query parameter in the websocket connection url to `biz`. Each token should contain a claim with room permissions:
+*Currently only HMAC is supported, but new key types can be added in the future*
 
+
+## Connection Auth
+JWT tokens should be passed using an `access_token` query parameter in the websocket connection url to `biz`.  This does not currently validate any claims, just that the token has a valid signature. 
+
+
+
+## Room Auth
+JWT Tokens should be passed as a `"token"` parameter on the JoinMsg and Publish requests via websocket.  
 ```json
 {
-  "id": "...", // room id
+  "rid": "...", // room id
   "videopublish": true, // can a peer publish video
   "audiopublish": true // can a peer publish audio
 }

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,12 @@ require (
 	github.com/cloudwebrtc/go-protoo v0.0.0-20200602160428-0a199e23f7e0
 	github.com/cloudwebrtc/nats-protoo v0.0.0-20200604135451-87b43396e8de
 	github.com/coreos/etcd v3.3.22+incompatible // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/go-redis/redis/v7 v7.4.0
 	github.com/google/uuid v1.1.1
+	github.com/gorilla/websocket v1.4.2
 	github.com/klauspost/reedsolomon v1.9.9 // indirect
 	github.com/mmcloughlin/avo v0.0.0-20200523190732-4439b6b2c061 // indirect
 	github.com/notedit/sdp v0.0.4

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/pion/stun v0.3.5
 	github.com/pion/transport v0.10.1
 	github.com/pion/webrtc/v2 v2.2.23
+	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.19.0
 	github.com/shirou/gopsutil v2.20.6+incompatible
 	github.com/spf13/viper v1.7.1

--- a/kube/ion-chart/templates/config.yaml
+++ b/kube/ion-chart/templates/config.yaml
@@ -29,6 +29,16 @@ data:
     port = "8443"
     #allow_disconnected = true
 
+    [signal.auth_connection]
+    enabled = {{ .Values.biz.auth.connection.enabled }} 
+    key_type = "HMAC"
+    key = "{{.Values.biz.auth.connection.hmac}}"
+
+    [signal.auth_room]
+    enabled = {{ .Values.biz.auth.room.enabled }} 
+    key_type = "HMAC"
+    key = "{{.Values.biz.auth.room.hmac}}"
+
     [nats]
     url = "nats://{{ .Release.Name }}-nats-client:4222"
 

--- a/kube/ion-chart/templates/config.yaml
+++ b/kube/ion-chart/templates/config.yaml
@@ -27,7 +27,9 @@ data:
     #listen ip port
     host = "0.0.0.0"
     port = "8443"
-    #allow_disconnected = true
+
+    path = "/ws"
+    allow_disconnected = false 
 
     [signal.auth_connection]
     enabled = {{ .Values.biz.auth.connection.enabled }} 

--- a/kube/ion-chart/values.yaml
+++ b/kube/ion-chart/values.yaml
@@ -73,6 +73,13 @@ sfu:
     # Overrides the image tag whose default is the chart appVersion.
     tag: "v0.4.6"
 biz:
+  auth:
+    connection:
+      enabled: false 
+      hmac: 1q2dGu5pzikcrECJgW3ADfXX3EsmoD99SYvSVCpDsJrAqxou5tUNbHPvkEFI4bTS 
+    room:
+      enabled: false 
+      hmac: 1q2dGu5pzikcrECJgW3ADfXX3EsmoD99SYvSVCpDsJrAqxou5tUNbHPvkEFI4bTS
   image:
     repository: pionwebrtc/ion-biz 
     pullPolicy: IfNotPresent

--- a/pkg/conf/biz/conf.go
+++ b/pkg/conf/biz/conf.go
@@ -45,7 +45,7 @@ type signal struct {
 	Cert              string `mapstructure:"cert"`
 	Key               string `mapstructure:"key"`
 	WebSocketPath     string `mapstructure:"path"`
-	Authenticate      bool   `mapstructure:"authenticate"`
+	Authorization     bool   `mapstructure:"authorization"`
 	AllowDisconnected bool   `mapstructure:"allow_disconnected"`
 }
 

--- a/pkg/conf/biz/conf.go
+++ b/pkg/conf/biz/conf.go
@@ -40,11 +40,13 @@ type etcd struct {
 }
 
 type signal struct {
-	Host string `mapstructure:"host"`
-	Port int    `mapstructure:"port"`
-	Cert string `mapstructure:"cert"`
-	Key  string `mapstructure:"key"`
-	AllowDisconnected bool `mapstructure:"allow_disconnected"`
+	Host              string `mapstructure:"host"`
+	Port              int    `mapstructure:"port"`
+	Cert              string `mapstructure:"cert"`
+	Key               string `mapstructure:"key"`
+	WebSocketPath     string `mapstructure:"path"`
+	Authenticate      bool   `mapstructure:"authenticate"`
+	AllowDisconnected bool   `mapstructure:"allow_disconnected"`
 }
 
 type nats struct {

--- a/pkg/conf/biz/conf.go
+++ b/pkg/conf/biz/conf.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/dgrijalva/jwt-go"
 	"github.com/spf13/viper"
 )
 
@@ -45,8 +46,24 @@ type signal struct {
 	Cert              string `mapstructure:"cert"`
 	Key               string `mapstructure:"key"`
 	WebSocketPath     string `mapstructure:"path"`
-	Authorization     bool   `mapstructure:"authorization"`
 	AllowDisconnected bool   `mapstructure:"allow_disconnected"`
+
+	AuthConnection AuthConfig `mapstructure:"auth_connection"`
+	AuthRoom       AuthConfig `mapstructure:"auth_room"`
+}
+
+type AuthConfig struct {
+	Enabled bool   `mapstructure:"enabled"`
+	Key     string `mapstructure:"key"`
+	KeyType string `mapstructure:"key_type"`
+}
+
+func (a AuthConfig) KeyFunc(t *jwt.Token) (interface{}, error) {
+	switch a.KeyType {
+	//TODO: add more support for keytypes here
+	default:
+		return []byte(a.Key), nil
+	}
 }
 
 type nats struct {

--- a/pkg/node/biz/dispatch.go
+++ b/pkg/node/biz/dispatch.go
@@ -51,7 +51,7 @@ func authenticateRoom(msgType interface{}, connectionClaims *signal.Claims, auth
 	if t := authenticatable.Token(); t != "" {
 		token, err := jwt.ParseWithClaims(t, &signal.Claims{}, roomAuth.KeyFunc)
 		if err != nil {
-			log.Debugf("authenticateRoom: Error parsing token: %#v", err)
+			log.Debugf("authenticateRoom: Error parsing token: %v", err)
 			return errorInvalidRoomToken
 		}
 		log.Debugf("authenticateRoom: Got Token %#v", token)

--- a/pkg/node/biz/init.go
+++ b/pkg/node/biz/init.go
@@ -2,6 +2,7 @@ package biz
 
 import (
 	nprotoo "github.com/cloudwebrtc/nats-protoo"
+	conf "github.com/pion/ion/pkg/conf/biz"
 	"github.com/pion/ion/pkg/discovery"
 	"github.com/pion/ion/pkg/log"
 )
@@ -14,15 +15,17 @@ var (
 	protoo   *nprotoo.NatsProtoo
 	rpcs     map[string]*nprotoo.Requestor
 	services map[string]discovery.Node
+	roomAuth conf.AuthConfig
 )
 
 // Init func
-func Init(dcID, nodeID, rpcID, eventID string, natsURL string) {
+func Init(dcID, nodeID, rpcID, eventID string, natsURL string, roomAuth conf.AuthConfig) {
 	dc = dcID
 	nid = nodeID
 	services = make(map[string]discovery.Node)
 	rpcs = make(map[string]*nprotoo.Requestor)
 	protoo = nprotoo.NewNatsProtoo(natsURL)
+	roomAuth = roomAuth
 }
 
 // WatchServiceNodes .

--- a/pkg/node/biz/init.go
+++ b/pkg/node/biz/init.go
@@ -19,13 +19,13 @@ var (
 )
 
 // Init func
-func Init(dcID, nodeID, rpcID, eventID string, natsURL string, roomAuth conf.AuthConfig) {
+func Init(dcID, nodeID, rpcID, eventID string, natsURL string, authConf conf.AuthConfig) {
 	dc = dcID
 	nid = nodeID
 	services = make(map[string]discovery.Node)
 	rpcs = make(map[string]*nprotoo.Requestor)
 	protoo = nprotoo.NewNatsProtoo(natsURL)
-	roomAuth = roomAuth
+	roomAuth = authConf
 }
 
 // WatchServiceNodes .

--- a/pkg/proto/biz.go
+++ b/pkg/proto/biz.go
@@ -18,6 +18,12 @@ func (m *ClientUserInfo) UnmarshalBinary(data []byte) error {
 	return json.Unmarshal(data, m)
 }
 
+type RoomClaims struct {
+	ID           string `json:"id,omitempty"`
+	Videopublish bool   `json:"videopublish,omitempty"`
+	Audiopublish bool   `json:"audiopublish,omitempty"`
+}
+
 type RoomInfo struct {
 	RID RID `json:"rid"`
 	UID UID `json:"uid"`

--- a/pkg/proto/biz.go
+++ b/pkg/proto/biz.go
@@ -20,8 +20,8 @@ func (m *ClientUserInfo) UnmarshalBinary(data []byte) error {
 
 type RoomClaims struct {
 	ID           string `json:"id,omitempty"`
-	Videopublish bool   `json:"videopublish,omitempty"`
-	Audiopublish bool   `json:"audiopublish,omitempty"`
+	VideoPublish bool   `json:"videopublish,omitempty"`
+	AudioPublish bool   `json:"audiopublish,omitempty"`
 }
 
 type RoomInfo struct {

--- a/pkg/proto/biz.go
+++ b/pkg/proto/biz.go
@@ -6,6 +6,11 @@ import (
 	"github.com/pion/webrtc/v2"
 )
 
+type Authenticatable interface {
+	Room() RoomInfo
+	Token() string
+}
+
 type ClientUserInfo struct {
 	Name string `json:"name"`
 }
@@ -19,7 +24,7 @@ func (m *ClientUserInfo) UnmarshalBinary(data []byte) error {
 }
 
 type RoomClaims struct {
-	ID           string `json:"id,omitempty"`
+	RID          string `json:"rid,omitempty"`
 	VideoPublish bool   `json:"videopublish,omitempty"`
 	AudioPublish bool   `json:"audiopublish,omitempty"`
 }
@@ -63,6 +68,13 @@ type JoinMsg struct {
 	Info ClientUserInfo `json:"info"`
 }
 
+func (j *JoinMsg) Token() string {
+	return j.RoomToken.Token
+}
+func (j *JoinMsg) Room() RoomInfo {
+	return j.RoomInfo
+}
+
 type LeaveMsg struct {
 	RoomInfo
 	Info ClientUserInfo `json:"info"`
@@ -70,8 +82,16 @@ type LeaveMsg struct {
 
 type PublishMsg struct {
 	RoomInfo
+	RoomToken
 	RTCInfo
 	Options PublishOptions `json:"options"`
+}
+
+func (p *PublishMsg) Token() string {
+	return p.RoomToken.Token
+}
+func (p *PublishMsg) Room() RoomInfo {
+	return p.RoomInfo
 }
 
 type PublishResponseMsg struct {

--- a/pkg/proto/biz.go
+++ b/pkg/proto/biz.go
@@ -23,12 +23,6 @@ func (m *ClientUserInfo) UnmarshalBinary(data []byte) error {
 	return json.Unmarshal(data, m)
 }
 
-type RoomClaims struct {
-	RID          string `json:"rid,omitempty"`
-	VideoPublish bool   `json:"videopublish,omitempty"`
-	AudioPublish bool   `json:"audiopublish,omitempty"`
-}
-
 type RoomToken struct {
 	Token string `json:"token,omitempty"`
 }

--- a/pkg/proto/biz.go
+++ b/pkg/proto/biz.go
@@ -24,6 +24,10 @@ type RoomClaims struct {
 	AudioPublish bool   `json:"audiopublish,omitempty"`
 }
 
+type RoomToken struct {
+	Token string `json:"token,omitempty"`
+}
+
 type RoomInfo struct {
 	RID RID `json:"rid"`
 	UID UID `json:"uid"`
@@ -55,6 +59,7 @@ type TrackMap map[string][]TrackInfo
 
 type JoinMsg struct {
 	RoomInfo
+	RoomToken
 	Info ClientUserInfo `json:"info"`
 }
 

--- a/pkg/signal/handle.go
+++ b/pkg/signal/handle.go
@@ -30,7 +30,7 @@ func in(transport *transport.WebSocketTransport, request *http.Request) {
 	id := peerID[0]
 	log.Infof("signal.in, id => %s", id)
 	peer := newPeer(id, transport)
-	claims := ForContext(request.Context())
+	connectionClaims := ForContext(request.Context())
 
 	handleRequest := func(request pr.Request, accept func(interface{}), reject func(errorCode int, errorReason string)) {
 		defer util.Recover("signal.in handleRequest")
@@ -49,7 +49,7 @@ func in(transport *transport.WebSocketTransport, request *http.Request) {
 		}
 
 		log.Infof("signal.in handleRequest id=%s method => %s", peer.ID(), method)
-		bizCall(method, peer, data, claims, accept, reject)
+		bizCall(method, peer, data, connectionClaims, accept, reject)
 	}
 
 	handleNotification := func(notification pr.Notification) {
@@ -70,7 +70,7 @@ func in(transport *transport.WebSocketTransport, request *http.Request) {
 
 		// msg := data.(map[string]interface{})
 		log.Infof("signal.in handleNotification id=%s method => %s", peer.ID(), method)
-		bizCall(method, peer, data, claims, emptyAccept, reject)
+		bizCall(method, peer, data, connectionClaims, emptyAccept, reject)
 	}
 
 	handleClose := func(code int, err string) {
@@ -90,7 +90,7 @@ func in(transport *transport.WebSocketTransport, request *http.Request) {
 						RoomInfo: proto.RoomInfo{RID: room.ID()},
 					}
 					msgStr, _ := json.Marshal(msg)
-					bizCall(proto.ClientLeave, peer, msgStr, claims, emptyAccept, reject)
+					bizCall(proto.ClientLeave, peer, msgStr, connectionClaims, emptyAccept, reject)
 				}
 				room.RemovePeer(peer.ID())
 			}

--- a/pkg/signal/handle.go
+++ b/pkg/signal/handle.go
@@ -15,15 +15,24 @@ import (
 	"github.com/pion/ion/pkg/util"
 )
 
+var (
+	errorTokenClaimsInvalid = errors.Errorf("Token claims invalid: must have RID or UID")
+)
+
 // Claims supported in JWT
 type Claims struct {
+	UID string `json:"uid"`
+	RID string `json:"rid"`
 	*jwt.StandardClaims
-	*proto.RoomClaims
 }
 
 func (c *Claims) Valid() error {
-	if c.RID == "" {
-		return errors.Errorf("Token must have RID")
+	if c.RID == "" && c.UID == "" {
+		return errorTokenClaimsInvalid
+	}
+
+	if c.StandardClaims != nil {
+		return c.StandardClaims.Valid()
 	}
 	return nil
 }

--- a/pkg/signal/handle.go
+++ b/pkg/signal/handle.go
@@ -8,6 +8,7 @@ import (
 	pr "github.com/cloudwebrtc/go-protoo/peer"
 	"github.com/cloudwebrtc/go-protoo/transport"
 	"github.com/dgrijalva/jwt-go"
+	"github.com/pkg/errors"
 
 	"github.com/pion/ion/pkg/log"
 	"github.com/pion/ion/pkg/proto"
@@ -18,6 +19,13 @@ import (
 type Claims struct {
 	*jwt.StandardClaims
 	*proto.RoomClaims
+}
+
+func (c *Claims) Valid() error {
+	if c.RID == "" {
+		return errors.Errorf("Token must have RID")
+	}
+	return nil
 }
 
 func in(transport *transport.WebSocketTransport, request *http.Request) {

--- a/pkg/signal/init.go
+++ b/pkg/signal/init.go
@@ -34,7 +34,10 @@ func Init(conf WebSocketServerConfig, allowDisconnected bool, bizEntry BizEntry)
 	bizCall = bizEntry
 	allowClientDisconnect = allowDisconnected
 	go stat()
-	panic(NewWebSocketServer(conf, in))
+	go func() {
+		panic(NewWebSocketServer(conf, in))
+	}()
+
 }
 
 func stat() {

--- a/pkg/signal/init.go
+++ b/pkg/signal/init.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/cloudwebrtc/go-protoo/peer"
-	"github.com/cloudwebrtc/go-protoo/server"
 	"github.com/pion/ion/pkg/log"
 	"github.com/pion/ion/pkg/proto"
 )
@@ -15,6 +14,7 @@ import (
 type AcceptFunc peer.AcceptFunc
 type RejectFunc peer.RejectFunc
 type RespondFunc peer.RespondFunc
+type BizEntry func(method string, peer *Peer, msg json.RawMessage, claims *Claims, accept RespondFunc, reject RejectFunc)
 
 const (
 	errInvalidMethod = "method not found"
@@ -23,25 +23,18 @@ const (
 )
 
 var (
-	bizCall               func(method string, peer *Peer, msg json.RawMessage, accept RespondFunc, reject RejectFunc)
-	wsServer              *server.WebSocketServer
+	bizCall               BizEntry
 	rooms                 = make(map[proto.RID]*Room)
 	roomLock              sync.RWMutex
 	allowClientDisconnect bool
 )
 
-func Init(host string, port int, cert, key string, allowDisconnected bool, bizEntry func(method string, peer *Peer, msg json.RawMessage, accept RespondFunc, reject RejectFunc)) {
-	wsServer = server.NewWebSocketServer(in)
-	config := server.DefaultConfig()
-	config.Host = host
-	config.Port = port
-	config.CertFile = cert
-	config.KeyFile = key
-	config.HTMLRoot = "web"
+// Init biz signaling
+func Init(conf WebSocketServerConfig, allowDisconnected bool, bizEntry BizEntry) {
 	bizCall = bizEntry
 	allowClientDisconnect = allowDisconnected
-	go wsServer.Bind(config)
 	go stat()
+	panic(NewWebSocketServer(conf, in))
 }
 
 func stat() {

--- a/pkg/signal/server.go
+++ b/pkg/signal/server.go
@@ -19,14 +19,10 @@ type WebSocketServerConfig struct {
 	CertFile      string
 	KeyFile       string
 	WebSocketPath string
-	Authenticate  bool
+	Authorization bool
 }
 
 type MsgHandler func(ws *transport.WebSocketTransport, request *http.Request)
-
-type WebSocketServer struct {
-	handleWebSocket func(ws *transport.WebSocketTransport, request *http.Request)
-}
 
 type contextKey struct {
 	name string
@@ -61,9 +57,9 @@ func getClaims(r *http.Request) (*Claims, error) {
 	return token.Claims.(*Claims), nil
 }
 
-func handler(authenticate bool, msgHandler MsgHandler) func(w http.ResponseWriter, r *http.Request) {
+func handler(authorization bool, msgHandler MsgHandler) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if authenticate {
+		if authorization {
 			claims, err := getClaims(r)
 
 			if err != nil {
@@ -96,7 +92,7 @@ func handler(authenticate bool, msgHandler MsgHandler) func(w http.ResponseWrite
 // NewWebSocketServer for signaling
 func NewWebSocketServer(cfg WebSocketServerConfig, msgHandler MsgHandler) error {
 	// Websocket handle func
-	http.HandleFunc(cfg.WebSocketPath, handler(cfg.Authenticate, msgHandler))
+	http.HandleFunc(cfg.WebSocketPath, handler(cfg.Authorization, msgHandler))
 
 	if cfg.CertFile == "" || cfg.KeyFile == "" {
 		logger.Infof("non-TLS WebSocketServer listening on: %s:%d", cfg.Host, cfg.Port)

--- a/pkg/signal/server.go
+++ b/pkg/signal/server.go
@@ -1,0 +1,114 @@
+package signal
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/cloudwebrtc/go-protoo/logger"
+	"github.com/cloudwebrtc/go-protoo/transport"
+	"github.com/dgrijalva/jwt-go"
+	"github.com/gorilla/websocket"
+	"github.com/pion/ion/pkg/log"
+)
+
+type WebSocketServerConfig struct {
+	Host          string
+	Port          int
+	CertFile      string
+	KeyFile       string
+	WebSocketPath string
+	Authenticate  bool
+}
+
+type MsgHandler func(ws *transport.WebSocketTransport, request *http.Request)
+
+type WebSocketServer struct {
+	handleWebSocket func(ws *transport.WebSocketTransport, request *http.Request)
+}
+
+type contextKey struct {
+	name string
+}
+
+var claimsCtxKey = &contextKey{"claims"}
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}
+
+func getClaims(r *http.Request) (*Claims, error) {
+	vars := r.URL.Query()
+
+	log.Debugf("Authenticating token")
+	tokenParam := vars["access_token"]
+	if tokenParam == nil || len(tokenParam) < 1 {
+		return nil, errors.New("no token")
+	}
+
+	tokenStr := tokenParam[0]
+	// Passing nil for keyFunc, since token is expected to be already verified (by a proxy)
+	token, err := jwt.ParseWithClaims(tokenStr, &Claims{}, nil)
+	if err != nil {
+		ve := err.(*jwt.ValidationError)
+		// ValidationErrorUnverifiable is expected since no keyFunc passed to ParseWithClaims
+		if ve.Errors != jwt.ValidationErrorUnverifiable {
+			return nil, errors.New("invalid token")
+		}
+	}
+	return token.Claims.(*Claims), nil
+}
+
+func handler(authenticate bool, msgHandler MsgHandler) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if authenticate {
+			claims, err := getClaims(r)
+
+			if err != nil {
+				log.Errorf("Error authenticating user => %s", err)
+				http.Error(w, "Invalid token", http.StatusForbidden)
+				return
+			}
+
+			// put it in context
+			ctx := context.WithValue(r.Context(), claimsCtxKey, claims)
+			// and call the next with our new context
+			r = r.WithContext(ctx)
+		}
+
+		responseHeader := http.Header{}
+		responseHeader.Add("Sec-WebSocket-Protocol", "protoo")
+		socket, err := upgrader.Upgrade(w, r, responseHeader)
+		if err != nil {
+			log.Errorf("Error upgrading => %s", err)
+			http.Error(w, "Error upgrading socket", http.StatusBadRequest)
+			return
+		}
+		wsTransport := transport.NewWebSocketTransport(socket)
+		wsTransport.Start()
+
+		msgHandler(wsTransport, r)
+	}
+}
+
+// NewWebSocketServer for signaling
+func NewWebSocketServer(cfg WebSocketServerConfig, msgHandler MsgHandler) error {
+	// Websocket handle func
+	http.HandleFunc(cfg.WebSocketPath, handler(cfg.Authenticate, msgHandler))
+
+	if cfg.CertFile == "" || cfg.KeyFile == "" {
+		logger.Infof("non-TLS WebSocketServer listening on: %s:%d", cfg.Host, cfg.Port)
+		return http.ListenAndServe(cfg.Host+":"+strconv.Itoa(cfg.Port), nil)
+	} else {
+		logger.Infof("TLS WebSocketServer listening on: %s:%d", cfg.Host, cfg.Port)
+		return http.ListenAndServeTLS(cfg.Host+":"+strconv.Itoa(cfg.Port), cfg.CertFile, cfg.KeyFile, nil)
+	}
+}
+
+// ForContext finds the request claims from the context.
+func ForContext(ctx context.Context) *Claims {
+	raw, _ := ctx.Value(claimsCtxKey).(*Claims)
+	return raw
+}

--- a/pkg/signal/server.go
+++ b/pkg/signal/server.go
@@ -37,7 +37,7 @@ var upgrader = websocket.Upgrader{
 	},
 }
 
-func getClaims(connectionAuth conf.AuthConfig, r *http.Request) (*jwt.MapClaims, error) {
+func getClaims(connectionAuth conf.AuthConfig, r *http.Request) (*Claims, error) {
 	vars := r.URL.Query()
 
 	log.Debugf("Authenticating token")
@@ -50,12 +50,11 @@ func getClaims(connectionAuth conf.AuthConfig, r *http.Request) (*jwt.MapClaims,
 
 	log.Debugf("checking claims on token %v", tokenStr)
 	// Passing nil for keyFunc, since token is expected to be already verified (by a proxy)
-	token, err := jwt.ParseWithClaims(tokenStr, &jwt.MapClaims{}, connectionAuth.KeyFunc)
+	token, err := jwt.ParseWithClaims(tokenStr, &Claims{}, connectionAuth.KeyFunc)
 	if err != nil {
-		// ValidationErrorUnverifiable is expected since no keyFunc passed to ParseWithClaims
 		return nil, err
 	}
-	return token.Claims.(*jwt.MapClaims), nil
+	return token.Claims.(*Claims), nil
 }
 
 func handler(connectionAuth conf.AuthConfig, msgHandler MsgHandler) func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This adds support for jwt based authorization. The issuance and verification of the jwt should happen by other services (i.e. verificaiton by [envoy jwt auth](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/http/jwt_authn/v2alpha/config.proto), issuance by [auth0](http://auth0.com/)). Ion defines a set of claims that it enforces:

```
type RoomClaims struct {
	ID           string `json:"id,omitempty"`
	Videopublish bool   `json:"videopublish,omitempty"`
	Audiopublish bool   `json:"audiopublish,omitempty"`
}
```

This is a draft PR. Right now it is only enforcing that the claim `ID` matches the `RID` being interacted with. Will need to do some more work to support the `videopublish` and `audiopublish`. Right now it only supports one room per token. We might want to allow a list of room claims. What do you guys think?

Resolves #78