### PR TITLE
Add description field to media stream

### DIFF
--- a/pkg/node/biz/client.go
+++ b/pkg/node/biz/client.go
@@ -50,7 +50,7 @@ func join(peer *signal.Peer, msg proto.JoinMsg) (interface{}, *nprotoo.Error) {
 				log.Errorf("Unmarshal pub response %v", err)
 				return
 			}
-			log.Infof("IslbGetPubs: result=%v", result)
+			log.Infof("IslbGetPubs: result=%v", resMsg)
 			for _, pub := range resMsg.Pubs {
 				if pub.MID == "" {
 					continue
@@ -128,7 +128,7 @@ func publish(peer *signal.Peer, msg proto.PublishMsg) (interface{}, *nprotoo.Err
 	if !found {
 		return nil, util.NewNpError(500, "Not found any node for islb.")
 	}
-	islb.AsyncRequest(proto.IslbOnStreamAdd, util.Map("rid", rid, "nid", nid, "uid", uid, "mid", mid, "tracks", tracks))
+	islb.AsyncRequest(proto.IslbOnStreamAdd, util.Map("rid", rid, "nid", nid, "uid", uid, "mid", mid, "tracks", tracks, "description", options.Description))
 	return result, nil
 }
 

--- a/pkg/proto/biz.go
+++ b/pkg/proto/biz.go
@@ -35,6 +35,7 @@ type PublishOptions struct {
 	Video       bool   `json:"video"`
 	Screen      bool   `json:"screen"`
 	TransportCC bool   `json:"transportCC,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 type SubscribeOptions struct {
@@ -105,8 +106,9 @@ type TrickleMsg struct {
 
 type StreamAddMsg struct {
 	MediaInfo
-	Info   ClientUserInfo `json:"info"`
-	Tracks TrackMap       `json:"tracks"`
+	Info        ClientUserInfo `json:"info"`
+	Tracks      TrackMap       `json:"tracks"`
+	Description string         `json:"description,omitempty"`
 }
 
 type StreamRemoveMsg struct {

--- a/pkg/proto/islb.go
+++ b/pkg/proto/islb.go
@@ -2,8 +2,9 @@ package proto
 
 type PubInfo struct {
 	MediaInfo
-	Info   ClientUserInfo `json:"info"`
-	Tracks TrackMap       `json:"tracks"`
+	Info        ClientUserInfo `json:"info"`
+	Tracks      TrackMap       `json:"tracks"`
+	Description string         `json:"description,omitempty"`
 }
 
 type GetPubResp struct {


### PR DESCRIPTION
#### Description
 In some cases, there is a business need to distinguish media streams on remote end. For example, a client can implement different logic and visualization for screenshare than the camera stream. This allows adding additional metadata in form of 'description' field to a media stream that will be propagated to the remote end.

#### SDK changes PR: https://github.com/pion/ion-sdk-js/pull/32


#### Reference issue
Fixes #...
