### PR TITLE
fix: peers avatar and extraInfo not updating on redis

### DIFF
--- a/apps/room/server/room_signal.go
+++ b/apps/room/server/room_signal.go
@@ -97,8 +97,6 @@ func (s *RoomSignalService) Signal(stream room.RoomSignal_SignalServer) error {
 
 func (s *RoomSignalService) Join(in *room.Request_Join, stream room.RoomSignal_SignalServer) (*room.Reply_Join, *Peer, error) {
 	pinfo := in.Join.Peer
-	sid := pinfo.Sid
-	uid := pinfo.Uid
 
 	if pinfo == nil || pinfo.Sid == "" && pinfo.Uid == "" {
 		reply := &room.Reply_Join{
@@ -113,6 +111,10 @@ func (s *RoomSignalService) Join(in *room.Request_Join, stream room.RoomSignal_S
 		}
 		return reply, nil, status.Errorf(codes.Internal, "sid/uid is empty")
 	}
+
+	sid := pinfo.Sid
+	uid := pinfo.Uid
+
 	key := util.GetRedisRoomKey(sid)
 	// create in redis if room not exist
 	if sid == "" {

--- a/apps/room/server/room_signal.go
+++ b/apps/room/server/room_signal.go
@@ -181,7 +181,7 @@ func (s *RoomSignalService) Join(in *room.Request_Join, stream room.RoomSignal_S
 	// store peer to redis
 	key = util.GetRedisPeerKey(sid, uid)
 	err := s.rs.redis.HMSetTTL(roomRedisExpire, key, "sid", sid, "uid", uid, "dest", in.Join.Peer.Destination,
-		"name", in.Join.Peer.DisplayName, "role", in.Join.Peer.Role.String(), "protocol", in.Join.Peer.Protocol.String(), "direction", in.Join.Peer.Direction.String())
+		"name", in.Join.Peer.DisplayName, "role", in.Join.Peer.Role.String(), "protocol", in.Join.Peer.Protocol.String(), "direction", in.Join.Peer.Direction.String(), "avatar", in.Join.Peer.Avatar, "info", in.Join.Peer.ExtraInfo)
 	if err != nil {
 		reply := &room.Reply_Join{
 			Join: &room.JoinReply{


### PR DESCRIPTION

#### Description
Types declaration and usage for avatar and extraInfo for peer was implemented. 

But both the fields for peers are not initialized while creating peers records on  redis. 

This PR will set the avatar and extraInfo to redis while the peers are created. 
