### PR TITLE
fix: extraInfo and avatar are not reflecting on UpdatePeer and AddPeer 

### DIFF
--- a/apps/room/server/room_service.go
+++ b/apps/room/server/room_service.go
@@ -227,6 +227,8 @@ func (s *RoomService) AddPeer(ctx context.Context, in *room.AddPeerRequest) (*ro
 	role := in.Peer.Role.String()
 	protocol := in.Peer.Protocol.String()
 	direction := in.Peer.Direction.String()
+	avatar := in.Peer.Avatar
+	extraInfo := in.Peer.ExtraInfo
 
 	// check room exist
 	key := util.GetRedisRoomKey(sid)
@@ -273,7 +275,8 @@ func (s *RoomService) AddPeer(ctx context.Context, in *room.AddPeerRequest) (*ro
 	// store peer to redis
 	key = util.GetRedisPeerKey(sid, uid)
 	err := s.redis.HMSetTTL(roomRedisExpire, key, "sid", sid, "uid", uid, "dest", dest,
-		"name", name, "role", role, "protocol", protocol, "direction", direction)
+		"name", name, "role", role, "protocol", protocol, "direction", direction, 
+		"avatar", avatar, "info", extraInfo)
 
 	if err != nil {
 		return &room.AddPeerReply{
@@ -308,6 +311,9 @@ func (s *RoomService) UpdatePeer(ctx context.Context, in *room.UpdatePeerRequest
 	role := in.Peer.Role.String()
 	protocol := in.Peer.Protocol.String()
 	direction := in.Peer.Direction.String()
+	avatar := in.Peer.Avatar
+	extraInfo := in.Peer.ExtraInfo
+
 
 	// check room exist
 	key := util.GetRedisRoomKey(sid)
@@ -359,7 +365,7 @@ func (s *RoomService) UpdatePeer(ctx context.Context, in *room.UpdatePeerRequest
 	key = util.GetRedisPeerKey(sid, uid)
 
 	err := s.redis.HMSetTTL(roomRedisExpire, key, "sid", sid, "uid", uid, "destination", destination,
-		"name", name, "role", role, "protocol", protocol, "direction", direction)
+		"name", name, "role", role, "protocol", protocol, "direction", direction,"avatar", avatar, "info", extraInfo )
 
 	if err != nil {
 		return &room.UpdatePeerReply{

--- a/apps/room/server/room_signal.go
+++ b/apps/room/server/room_signal.go
@@ -97,8 +97,6 @@ func (s *RoomSignalService) Signal(stream room.RoomSignal_SignalServer) error {
 
 func (s *RoomSignalService) Join(in *room.Request_Join, stream room.RoomSignal_SignalServer) (*room.Reply_Join, *Peer, error) {
 	pinfo := in.Join.Peer
-	sid := pinfo.Sid
-	uid := pinfo.Uid
 
 	if pinfo == nil || pinfo.Sid == "" && pinfo.Uid == "" {
 		reply := &room.Reply_Join{
@@ -113,6 +111,10 @@ func (s *RoomSignalService) Join(in *room.Request_Join, stream room.RoomSignal_S
 		}
 		return reply, nil, status.Errorf(codes.Internal, "sid/uid is empty")
 	}
+
+	sid := pinfo.Sid
+	uid := pinfo.Uid
+
 	key := util.GetRedisRoomKey(sid)
 	// create in redis if room not exist
 	if sid == "" {

--- a/apps/room/server/room_signal.go
+++ b/apps/room/server/room_signal.go
@@ -181,7 +181,7 @@ func (s *RoomSignalService) Join(in *room.Request_Join, stream room.RoomSignal_S
 	// store peer to redis
 	key = util.GetRedisPeerKey(sid, uid)
 	err := s.rs.redis.HMSetTTL(roomRedisExpire, key, "sid", sid, "uid", uid, "dest", in.Join.Peer.Destination,
-		"name", in.Join.Peer.DisplayName, "role", in.Join.Peer.Role.String(), "protocol", in.Join.Peer.Protocol.String(), "direction", in.Join.Peer.Direction.String())
+		"name", in.Join.Peer.DisplayName, "role", in.Join.Peer.Role.String(), "protocol", in.Join.Peer.Protocol.String(), "direction", in.Join.Peer.Direction.String(), "avatar", in.Join.Peer.Avatar, "info", in.Join.Peer.ExtraInfo)
 	if err != nil {
 		reply := &room.Reply_Join{
 			Join: &room.JoinReply{


### PR DESCRIPTION
UpdatePeer (Method) - Has option to update all the fields except avatar and extraInfo. 

AddPeer(Method) - we can add peers with all peer fields except avatar and extraInfo.

This commit resolved both the issue, So we can add / update peers avatar and extraInfo.