### PR TITLE
fix: docker-start-services support multi-times execute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,10 @@ scripts-stop-services:
 
 docker-start-services:
 	docker-compose pull
-	docker network create ionnet
 	docker-compose -f docker-compose.yml up
 
 docker-stop-services:
-	docker-compose -f docker-compose.yml stop
+	docker-compose -f docker-compose.yml down
 
 test: go_deps start-services
 	go test \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,5 @@ services:
 
 networks:
   ionnet:
-    external: true
     name: ionnet
     driver: bridge


### PR DESCRIPTION
#### Description
Pure `docker-compose up/down`, not use external network.

#### Reference issue
Fixes #609
