### PR TITLE
ion-echo example, add TURN settings and RTT on top of remote video

### DIFF
--- a/examples/ion-echo/index.html
+++ b/examples/ion-echo/index.html
@@ -55,7 +55,10 @@
       <div class="row" id="buttons">
         <div class="col-12">
           <div class="btn-group" role="group" aria-label="...">
-            <button id="join-btn" type="button" class="btn btn-primary" onclick="join()">
+            <button id="connect-btn" type="button" class="btn btn-primary" onclick="connect()">
+              connect
+            </button>
+            <button id="join-btn" type="button" class="btn btn-primary" onclick="join()" disabled=true>
               join
             </button>
             <button id="publish-btn" type="button" class="btn btn-primary" onclick="start(false)" disabled=true>
@@ -68,6 +71,28 @@
               leave
             </button>
           </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-12">TURN
+          <form>
+            URL:
+            <input type="text" id="turnUrl">
+            username:
+            <input type="text" id="turnUsername">
+            credential:
+            <input type="text" id="turnCredential">
+            </form>
+            </div>
+            <div class="col-12">
+              <form>
+            Transport policy:
+            <select id="select-box-relay">
+              <option value="relay" selected="selected" >relay</option>
+              <option value="all">all</option>
+            </select>
+          </form>
         </div>
       </div>
 
@@ -168,6 +193,11 @@
           <span
             id="br-tag"
             style="position: absolute; left: 215px; top: 225px"
+            class="badge badge-primary"
+          ></span>
+          <span
+            id="rtt-tag"
+            style="position: absolute; left: 105px; top: 225px"
             class="badge badge-primary"
           ></span>
           <video


### PR DESCRIPTION
These changes will make it possible for users to perform the echo testing while using a TURN service between them and the server.

For the operation to work I had to add an additional phase, "Connect", to be performed before the "Join".

<img width="828" alt="Screenshot 2022-05-05 at 13 34 28" src="https://user-images.githubusercontent.com/3305097/166915133-e6fbe2d9-f3c4-41a8-a6bb-3574fac0acc4.png">


They also add an indication of the RTT, on top of the remote video, near the bitrate.

<img width="391" alt="Screenshot 2022-05-05 at 13 33 12" src="https://user-images.githubusercontent.com/3305097/166914967-e4baeb17-7cee-4ee3-86ac-1a6cba9aff81.png">

